### PR TITLE
Remove fix layers

### DIFF
--- a/fractalstream-backend-llvm/cabal.project
+++ b/fractalstream-backend-llvm/cabal.project
@@ -1,6 +1,22 @@
 packages: . ../fractalstream-core
 
+constraints: llvm-hs -shared-llvm
+
+allow-newer: llvm-hs:transformers, llvm-hs-pure:transformers, llvm-hs-pure:bytestring
+
 source-repository-package
     type: git
     location: https://github.com/mgrabmueller/disassembler
     tag: 15a15db1fba50fd0ce52f26f43550fbad5529bf8
+
+source-repository-package
+    type: git
+    location: https://github.com/matt-noonan/llvm-hs.git
+    tag: 46fbe902a83a4198f296e2062c767b34ecc6be65
+    subdir: llvm-hs
+
+source-repository-package
+    type: git
+    location: https://github.com/matt-noonan/llvm-hs.git
+    tag: 46fbe902a83a4198f296e2062c767b34ecc6be65
+    subdir: llvm-hs-pure

--- a/fractalstream-backend-llvm/src/Backend/LLVM/Code.hs
+++ b/fractalstream-backend-llvm/src/Backend/LLVM/Code.hs
@@ -25,7 +25,7 @@ import Control.Monad.Fix
 import Language.Type
 import Language.Code
 import Data.Indexed.Functor
-import Fcf (Exp, Eval, Pure1)
+import Fcf (Exp, Eval)
 import GHC.TypeLits
 import Data.String
 
@@ -422,7 +422,7 @@ compileCode :: forall m env t
             => (String -> Operand)
             -> Code '[] env t
             -> ReaderT (Context OperandPtr env) m (Op t)
-compileCode getExtern = indexedFold @(CtxOp m) @(Fix (CodeF '[] (Pure1 Value))) @(CodeF '[] (Pure1 Value)) $ \case
+compileCode getExtern = indexedFold @(CtxOp m) @(CodeF '[] (FIX ValueF)) $ \case
 
   Block _ body end -> sequence_ body >> end
 

--- a/fractalstream-backend-llvm/src/Backend/LLVM/Value.hs
+++ b/fractalstream-backend-llvm/src/Backend/LLVM/Value.hs
@@ -43,7 +43,7 @@ buildValue :: forall env t' m
            => (String -> Operand)
            -> Value '(env, t')
            -> ReaderT (Context OperandPtr env) m (Op t')
-buildValue getExtern = indexedFold @(CtxOp m) @(Fix ValueF) @ValueF go'
+buildValue getExtern = indexedFold go'
   where
     go' :: forall et. ValueF (CtxOp m) et -> Eval (CtxOp m et)
     go' x = case toIndex x of { EnvType _ -> go x }
@@ -220,22 +220,10 @@ buildValue getExtern = indexedFold @(CtxOp m) @(Fix ValueF) @ValueF go'
 
       NEq {} -> error "unhandled NEq type"
 
-      LEI x y -> ((,) <$> x <*> y) >>= \case
-        (IntegerOp lhs, IntegerOp rhs) -> BooleanOp <$> icmp P.SLE lhs rhs
       LTI x y -> ((,) <$> x <*> y) >>= \case
          (IntegerOp lhs, IntegerOp rhs) -> BooleanOp <$> icmp P.SLT lhs rhs
-      GEI x y -> ((,) <$> x <*> y) >>= \case
-         (IntegerOp lhs, IntegerOp rhs) -> BooleanOp <$> icmp P.SGE lhs rhs
-      GTI x y -> ((,) <$> x <*> y) >>= \case
-         (IntegerOp lhs, IntegerOp rhs) -> BooleanOp <$> icmp P.SGT lhs rhs
-      LEF x y -> ((,) <$> x <*> y) >>= \case
-         (RealOp lhs, RealOp rhs) -> BooleanOp <$> fcmp P.OLE lhs rhs
       LTF x y -> ((,) <$> x <*> y) >>= \case
          (RealOp lhs, RealOp rhs) -> BooleanOp <$> fcmp P.OLT lhs rhs
-      GEF x y -> ((,) <$> x <*> y) >>= \case
-         (RealOp lhs, RealOp rhs) -> BooleanOp <$> fcmp P.OGE lhs rhs
-      GTF x y -> ((,) <$> x <*> y) >>= \case
-         (RealOp lhs, RealOp rhs) -> BooleanOp <$> fcmp P.OGT lhs rhs
 
       AddI x y -> ((,) <$> x <*> y) >>= \case
          (IntegerOp lhs, IntegerOp rhs) -> IntegerOp <$> add lhs rhs

--- a/fractalstream-core/src/Actor/Viewer/Complex.hs
+++ b/fractalstream-core/src/Actor/Viewer/Complex.hs
@@ -323,9 +323,9 @@ complexToReal :: ( KnownType rt, KnownEnvironment env
               -> Code eff ( '(px, 'RealT) ': '(z, 'ComplexT) ': env ) rt
               -> Code eff env rt
 complexToReal reZ imZ vpx =
-  let z = Fix (AddC (Fix (R2C (Fix (Var Proxy RealType reZ))))
-                    (Fix (MulC (Fix (Const (Scalar ComplexType (0 :+ 1))))
-                               (Fix (R2C (Fix (Var Proxy RealType imZ)))))))
-      px = Fix (Var Proxy RealType vpx)
+  let z = AddC (R2C (Var Proxy RealType reZ))
+               (MulC (Const (Scalar ComplexType (0 :+ 1)))
+                     (R2C (Var Proxy RealType imZ)))
+      px = Var Proxy RealType vpx
   in  let_ z  typeProxy
     . let_ px typeProxy

--- a/fractalstream-core/src/Language/Code/InterpretIO.hs
+++ b/fractalstream-core/src/Language/Code/InterpretIO.hs
@@ -20,7 +20,7 @@ import Data.Indexed.Functor
 import Data.IORef
 import Control.Monad.State
 import GHC.TypeLits
-import Fcf (Exp, Eval, Pure1)
+import Fcf (Exp, Eval)
 import Data.Kind
 
 data ScalarIORefM :: (Environment, FSType) -> Exp Type
@@ -112,7 +112,7 @@ interpretToIO_ :: forall effs env t s
                -> Code effs env t
                -> StateT (Context IORefTypeOfBinding env, s) IO (HaskellType t)
 interpretToIO_ handlers =
-  indexedFold @(ScalarIORefMWith s) @(Fix (CodeF effs (Pure1 Value))) @(CodeF effs (Pure1 Value)) $ \case
+  indexedFold @(ScalarIORefMWith s) $ \case
     Let pf name vt v _ body -> recallIsAbsent (absentInTail pf) $ do
       (ctxRef, s) <- get
       value <- eval v

--- a/fractalstream-core/src/Language/Code/Simulator.hs
+++ b/fractalstream-core/src/Language/Code/Simulator.hs
@@ -11,7 +11,7 @@ import Data.Indexed.Functor
 
 import Control.Monad.State
 import GHC.TypeLits
-import Fcf (Exp, Eval, Pure1)
+import Fcf (Exp, Eval)
 import Data.Kind
 
 data HaskellTypeM :: Type -> (Environment, FSType) -> Exp Type
@@ -43,7 +43,7 @@ simulate :: forall effs env t s
           . Handlers effs (HaskellTypeM s)
          -> Code effs env t
          -> State (Context HaskellTypeOfBinding env, s) (HaskellType t)
-simulate handlers = indexedFold @(HaskellTypeM s) @(Fix (CodeF effs (Pure1 Value))) @(CodeF effs (Pure1 Value)) $ \case
+simulate handlers = indexedFold @(HaskellTypeM s) $ \case
   Let pf name vt v _ body -> recallIsAbsent (absentInTail pf) $ do
     (ctx, s) <- get
     value <- eval v

--- a/fractalstream-core/src/Language/Effect/Draw.hs
+++ b/fractalstream-core/src/Language/Effect/Draw.hs
@@ -154,19 +154,19 @@ pDrawCommand env = do
 
     pDrawPoint = withEnvironment env $ do
       tok_ "point" >> tok_ "at"
-      DrawPoint env . Fix . C2R2 <$> value_ EmptyContext
+      DrawPoint env . C2R2 <$> value_ EmptyContext
 
     pDrawLine = withEnvironment env $ do
       tok_ "line" >> tok_ "from"
       valueTokens <- manyTill anyToken (tok_ "to")
-      p1 <- Fix . C2R2 <$> nest (parseValueFromTokens env EmptyContext ComplexType valueTokens)
-      p2 <- Fix . C2R2 <$> value_ EmptyContext
+      p1 <- C2R2 <$> nest (parseValueFromTokens env EmptyContext ComplexType valueTokens)
+      p2 <- C2R2 <$> value_ EmptyContext
       pure (DrawLine env p1 p2)
 
     pDrawCircle fill = withEnvironment env $ do
       tok_ "circle" >> tok_ "at"
       valueTokens <- manyTill anyToken (tok_ "with")
-      center <- Fix . C2R2 <$> nest (parseValueFromTokens env EmptyContext ComplexType valueTokens)
+      center <- C2R2 <$> nest (parseValueFromTokens env EmptyContext ComplexType valueTokens)
       tok_ "radius"
       r <- value_ EmptyContext
       pure (DrawCircle env fill r center)
@@ -174,8 +174,8 @@ pDrawCommand env = do
     pDrawRect fill = withEnvironment env $ do
       tok_ "rectangle" >> tok_ "from"
       valueTokens <- manyTill anyToken (tok_ "to")
-      p1 <- Fix . C2R2 <$> nest (parseValueFromTokens env EmptyContext ComplexType valueTokens)
-      p2 <- Fix . C2R2 <$> value_ EmptyContext
+      p1 <- C2R2 <$> nest (parseValueFromTokens env EmptyContext ComplexType valueTokens)
+      p2 <- C2R2 <$> value_ EmptyContext
       pure (DrawRect env fill p1 p2)
 
     pDrawFilled = do

--- a/fractalstream-core/src/Language/Untyped/Value.hs
+++ b/fractalstream-core/src/Language/Untyped/Value.hs
@@ -1,9 +1,9 @@
+{-# language UndecidableInstances #-}
 module Language.Untyped.Value
   ( type Value
   , ValueF(..)
   , Fun(..)
   , ArithOp(..)
-  , CmpOp(..)
   , type ValueWith
   , substitute
   ) where
@@ -15,10 +15,11 @@ import Data.Recursive
 import Data.Kind
 import Data.Map (Map)
 import qualified Data.Map as Map
+import Fcf (Eval, Exp)
 
-type Value = Fix ValueF
+type Value = Eval (FIX ValueF)
 
-type ValueWith = Ann ValueF
+type ValueWith a = Ann ValueF a
 
 data Fun = Abs | Exp | Log | Sqrt | Sin | Cos | Tan | Sinh | Cosh | Tanh
          | Arcsin | Arccos | Arctan | Arcsinh | Arccosh | Arctanh
@@ -30,34 +31,84 @@ data ArithOp = Add | Sub | Mul | Div | Pow | Mod
              | Arctan2
   deriving (Eq, Ord, Show)
 
-data CmpOp = LE | LT | GE | GT
-  deriving (Eq, Ord, Show)
-
-data ValueF (value :: Type)
+data ValueF (value :: Exp Type)
   = ConstB Bool
   | ConstI Integer
   | ConstF Double
   | ConstC Double Double
   | ConstColor Color
   | Var String
-  | PairV value value
-  | ProjV1 value
-  | ProjV2 value
-  | Arith ArithOp value value
-  | Ap1 Fun value
-  | Or value value
-  | And value value
-  | Not value
-  | ITE value value value
-  | RGB value value value
-  | Blend value value value
-  | InvertRGB value
-  | Eql value value
-  | NEq value value
-  | Cmp CmpOp value value
-  deriving (Eq, Ord, Show, Functor, Foldable, Traversable)
+  | PairV (Eval value) (Eval value)
+  | ProjV1 (Eval value)
+  | ProjV2 (Eval value)
+  | Arith ArithOp (Eval value) (Eval value)
+  | Ap1 Fun (Eval value)
+  | Or (Eval value) (Eval value)
+  | And (Eval value) (Eval value)
+  | Not (Eval value)
+  | ITE (Eval value) (Eval value) (Eval value)
+  | RGB (Eval value) (Eval value) (Eval value)
+  | Blend (Eval value) (Eval value) (Eval value)
+  | InvertRGB (Eval value)
+  | Eql (Eval value) (Eval value)
+  | NEq (Eval value) (Eval value)
+  | LT (Eval value) (Eval value)
+
+deriving instance Eq   (Eval value) => Eq   (ValueF value)
+deriving instance Ord  (Eval value) => Ord  (ValueF value)
+deriving instance Show (Eval value) => Show (ValueF value)
+
+instance EFunctor ValueF where
+  emap f = \case
+    ConstB b -> ConstB b
+    ConstI n -> ConstI n
+    ConstF r -> ConstF r
+    ConstC r i -> ConstC r i
+    ConstColor c -> ConstColor c
+    Var v -> Var v
+    PairV x y -> PairV (f x) (f y)
+    ProjV1 p -> ProjV1 (f p)
+    ProjV2 p -> ProjV2 (f p)
+    Arith op x y -> Arith op (f x) (f y)
+    Ap1 fun x -> Ap1 fun (f x)
+    Or x y -> Or (f x) (f y)
+    And x y -> And (f x) (f y)
+    Not x -> Not (f x)
+    ITE c y n -> ITE (f c) (f y) (f n)
+    RGB r g b -> RGB (f r) (f g) (f b)
+    Blend t x y -> Blend (f t) (f x) (f y)
+    InvertRGB c -> InvertRGB (f c)
+    Eql x y -> Eql (f x) (f y)
+    NEq x y -> NEq (f x) (f y)
+    LT x y -> LT (f x) (f y)
+
+instance ETraversable ValueF where
+  etraverse f = \case
+    ConstB b -> pure $ ConstB b
+    ConstI n -> pure $ ConstI n
+    ConstF r -> pure $ ConstF r
+    ConstC r i -> pure $ ConstC r i
+    ConstColor c -> pure $ ConstColor c
+    Var v -> pure $ Var v
+    PairV x y -> PairV <$> f x <*> f y
+    ProjV1 p -> ProjV1 <$> f p
+    ProjV2 p -> ProjV2 <$> f p
+    Arith op x y -> Arith op <$> f x <*> f y
+    Ap1 fun x -> Ap1 fun <$> f x
+    Or x y -> Or <$> f x <*> f y
+    And x y -> And <$> f x <*> f y
+    Not x -> Not <$> f x
+    ITE c y n -> ITE <$> f c <*> f y <*> f n
+    RGB r g b -> RGB <$> f r <*> f g <*> f b
+    Blend t x y -> Blend <$> f t <*> f x <*> f y
+    InvertRGB c -> InvertRGB <$> f c
+    Eql x y -> Eql <$> f x <*> f y
+    NEq x y -> NEq <$> f x <*> f y
+    LT x y -> LT <$> f x <*> f y
+
+--, Functor, Foldable, Traversable)
 
 substitute :: Map String Value -> Value -> Value
 substitute m = fold $ \case
-  Var s -> Map.findWithDefault (Fix (Var s)) s m
-  other -> Fix other
+  Var s -> Map.findWithDefault (Var s) s m
+  other -> other

--- a/fractalstream-core/src/Language/Value/Transform.hs
+++ b/fractalstream-core/src/Language/Value/Transform.hs
@@ -7,50 +7,46 @@ import Data.Indexed.Functor
 import Language.Value
 
 import Data.Word (Word64)
-import Fcf
 
 pattern ConstIntI :: forall env. KnownEnvironment env
                   => Int64 -> Value '(env, 'IntegerT)
-pattern ConstIntI n = Fix (Const (Scalar IntegerType n))
+pattern ConstIntI n = Const (Scalar IntegerType n)
 
 pattern ConstIntF :: forall env. KnownEnvironment env
                   => Int64 -> Value '(env, 'RealT)
-pattern ConstIntF n = Fix (I2R (Fix (Const (Scalar IntegerType n))))
+pattern ConstIntF n = I2R (Const (Scalar IntegerType n))
 
 pattern ConstIntC :: forall env. KnownEnvironment env
                   => Int64 -> Value '(env, 'ComplexT)
-pattern ConstIntC n = Fix (R2C (Fix (I2R (Fix (Const (Scalar IntegerType n))))))
+pattern ConstIntC n = R2C (I2R (Const (Scalar IntegerType n)))
 
 integerPowers :: Value et0 -> Value et0
-integerPowers = indexedFold phi
+integerPowers = indexedFold @(FIX ValueF) phi
   where
-    phi :: forall et. ValueF (Pure1 Value) et -> Value et
+    phi :: forall et. Value et -> Value et
     phi = \case
 
       PowC x (ConstIntC n)
         | n == 0 -> ConstIntC 1
-        | n < 0  -> Fix (DivC (ConstIntC 1)
-                              (phi (PowC x (ConstIntC (-n)))))
-        | otherwise -> mkPow ComplexType (Fix .: MulC) x (fromIntegral n)
+        | n < 0  -> DivC (ConstIntC 1)
+                         (phi (PowC x (ConstIntC (-n))))
+        | otherwise -> mkPow ComplexType MulC x (fromIntegral n)
 
       PowF x (ConstIntF n)
         | n == 0 -> ConstIntF 1
-        | n < 0  -> Fix (DivF (ConstIntF 1)
-                              (phi (PowF x (ConstIntF (-n)))))
-        | otherwise -> mkPow RealType (Fix .: MulF) x (fromIntegral n)
+        | n < 0  -> DivF (ConstIntF 1)
+                         (phi (PowF x (ConstIntF (-n))))
+        | otherwise -> mkPow RealType MulF x (fromIntegral n)
 
       PowI x (ConstIntI n)
         | n == 0 -> ConstIntI 1
-        | n < 0  -> Fix (DivI (ConstIntI 1)
-                              (phi (PowI x (ConstIntI (-n)))))
-        | otherwise -> mkPow IntegerType (Fix .: MulI) x (fromIntegral n)
+        | n < 0  -> DivI (ConstIntI 1)
+                         (phi (PowI x (ConstIntI (-n))))
+        | otherwise -> mkPow IntegerType MulI x (fromIntegral n)
 
       -- TODO: |z|^2k -> (x^2 + y^2)^k, |z|^(2k+1) -> |z| * (x^2 + y^2)^k
 
-      etc -> Fix etc
-
-(.:) :: (c -> d) -> (a -> b -> c) -> (a -> b -> d)
-f .: g = \x -> f . g x
+      etc -> etc
 
 mkPow :: KnownEnvironment env
       => TypeProxy ty
@@ -81,71 +77,23 @@ mkPow _ty mul x0 n0 = go Nothing (bits n0) x0
 avoidSqrt :: Value et0 -> Value et0
 avoidSqrt = indexedFold phi
   where
-    phi :: forall et. ValueF (Pure1 Value) et -> Value et
+    phi :: forall et. Value et -> Value et
     phi = \case
 
-      LTF (Fix (AbsC z)) rhs ->
-        Fix (LTF (Fix (AddF (Fix (MulF (Fix (ReC z)) (Fix (ReC z)))) (Fix (MulF (Fix (ImC z)) (Fix (ImC z))))))
-                 (Fix (MulF (Fix (AbsF rhs)) rhs)))
+      LTF (AbsC z) rhs ->
+        LTF (AddF (MulF (ReC z) (ReC z)) (MulF (ImC z) (ImC z)))
+            (MulF (AbsF rhs) rhs)
 
-      LTF lhs (Fix (AbsC z)) ->
-        Fix (LTF (Fix (MulF (Fix (AbsF lhs)) lhs))
-                 (Fix (AddF (Fix (MulF (Fix (ReC z)) (Fix (ReC z)))) (Fix (MulF (Fix (ImC z)) (Fix (ImC z)))))))
+      LTF lhs (AbsC z) ->
+        LTF (MulF (AbsF lhs) lhs)
+            (AddF (MulF (ReC z) (ReC z)) (MulF (ImC z) (ImC z)))
 
-      LTF (Fix (AbsF x)) rhs ->
-        Fix (LTF (Fix (MulF x x))
-                 (Fix (MulF (Fix (AbsF rhs)) rhs)))
+      LTF (AbsF x) rhs ->
+        LTF (MulF x x)
+            (MulF (AbsF rhs) rhs)
 
-      LTF lhs (Fix (AbsF x)) ->
-        Fix (LTF (Fix (MulF (Fix (AbsF lhs)) lhs))
-                 (Fix (MulF x x)))
+      LTF lhs (AbsF x) ->
+        LTF (MulF (AbsF lhs) lhs)
+            (MulF x x)
 
-      LEF (Fix (AbsC z)) rhs ->
-        Fix (LEF (Fix (AddF (Fix (MulF (Fix (ReC z)) (Fix (ReC z)))) (Fix (MulF (Fix (ImC z)) (Fix (ImC z))))))
-                 (Fix (MulF (Fix (AbsF rhs)) rhs)))
-
-      LEF lhs (Fix (AbsC z)) ->
-        Fix (LEF (Fix (MulF (Fix (AbsF lhs)) lhs))
-                 (Fix (AddF (Fix (MulF (Fix (ReC z)) (Fix (ReC z)))) (Fix (MulF (Fix (ImC z)) (Fix (ImC z)))))))
-
-      LEF (Fix (AbsF x)) rhs ->
-        Fix (LEF (Fix (MulF x x))
-                 (Fix (MulF (Fix (AbsF rhs)) rhs)))
-
-      LEF lhs (Fix (AbsF x)) ->
-        Fix (LEF (Fix (MulF (Fix (AbsF lhs)) lhs))
-                 (Fix (MulF x x)))
-
-      GTF (Fix (AbsC z)) rhs ->
-        Fix (GTF (Fix (AddF (Fix (MulF (Fix (ReC z)) (Fix (ReC z)))) (Fix (MulF (Fix (ImC z)) (Fix (ImC z))))))
-                 (Fix (MulF (Fix (AbsF rhs)) rhs)))
-
-      GTF lhs (Fix (AbsC z)) ->
-        Fix (GTF (Fix (MulF (Fix (AbsF lhs)) lhs))
-                 (Fix (AddF (Fix (MulF (Fix (ReC z)) (Fix (ReC z)))) (Fix (MulF (Fix (ImC z)) (Fix (ImC z)))))))
-
-      GTF (Fix (AbsF x)) rhs ->
-        Fix (GTF (Fix (MulF x x))
-                 (Fix (MulF (Fix (AbsF rhs)) rhs)))
-
-      GTF lhs (Fix (AbsF x)) ->
-        Fix (GTF (Fix (MulF (Fix (AbsF lhs)) lhs))
-                 (Fix (MulF x x)))
-
-      GEF (Fix (AbsC z)) rhs ->
-        Fix (GEF (Fix (AddF (Fix (MulF (Fix (ReC z)) (Fix (ReC z)))) (Fix (MulF (Fix (ImC z)) (Fix (ImC z))))))
-                 (Fix (MulF (Fix (AbsF rhs)) rhs)))
-
-      GEF lhs (Fix (AbsC z)) ->
-        Fix (GEF (Fix (MulF (Fix (AbsF lhs)) lhs))
-                 (Fix (AddF (Fix (MulF (Fix (ReC z)) (Fix (ReC z)))) (Fix (MulF (Fix (ImC z)) (Fix (ImC z)))))))
-
-      GEF (Fix (AbsF x)) rhs ->
-        Fix (GEF (Fix (MulF x x))
-                 (Fix (MulF (Fix (AbsF rhs)) rhs)))
-
-      GEF lhs (Fix (AbsF x)) ->
-        Fix (GEF (Fix (MulF (Fix (AbsF lhs)) lhs))
-                 (Fix (MulF x x)))
-
-      etc -> Fix etc
+      etc -> etc

--- a/fractalstream-core/test/Language/Value/EvaluatorSpec.hs
+++ b/fractalstream-core/test/Language/Value/EvaluatorSpec.hs
@@ -3,7 +3,6 @@ module Language.Value.EvaluatorSpec (spec) where
 import Test.Hspec
 import Language.Value
 import Language.Value.Evaluator
-import Data.Indexed.Functor
 
 spec :: Spec
 spec = do
@@ -19,7 +18,7 @@ spec = do
           -- get computed by Haskell *before* it was
           -- turned into a Value.
           v1_outermost_add = case v1 of
-            Fix (AddF _ _) -> True
+            AddF _ _ -> True
             _ -> False
       v1_outermost_add `shouldBe` True
       evaluate v1 EmptyContext `shouldBe` 9
@@ -29,9 +28,9 @@ spec = do
     it "computes integer values from an empty context" $ do
       let v1, v2, v3, v4 :: Value '( '[], 'IntegerT)
           v1 = abs(20 - 30)
-          v2 = Fix (DivI (10 * 10) 20) - 30
-          v3 = Fix (DivI 20 7)
-          v4 = Fix (ModI 20 7)
+          v2 = DivI (10 * 10) 20 - 30
+          v3 = DivI 20 7
+          v4 = ModI 20 7
       evaluate v1 EmptyContext `shouldBe` 10
       evaluate v2 EmptyContext `shouldBe` (-25)
       evaluate v3 EmptyContext `shouldBe` 2
@@ -39,23 +38,23 @@ spec = do
 
     it "computes boolean values from an empty context" $ do
       let yes, no, v1, v2, v3, v4 :: Value '( '[], 'BooleanT)
-          yes = Fix (Const (Scalar BooleanType True ))
-          no  = Fix (Const (Scalar BooleanType False))
-          v1 = Fix (Eql RealType
-                      (cos(pi) + abs(10 - 20))
-                      (3 * 3))
-          v2 = Fix (Eql BooleanType
-                      (Fix (Or yes no))
-                      (Fix (And yes no)))
-          v3 = Fix (NEq IntegerType
-                      (Fix (DivI (10 * 10) 20) - 30)
-                      (50 - 75))
-          v4 = Fix (Eql (PairType IntegerType IntegerType)
-                      (Fix (PairV (PairType IntegerType IntegerType)
-                                  (Fix (DivI 20 7))
-                                  (Fix (ModI 20 7))))
-                      (Fix (PairV (PairType IntegerType IntegerType)
-                                  2 6)))
+          yes = Const (Scalar BooleanType True )
+          no  = Const (Scalar BooleanType False)
+          v1 = Eql RealType
+                   (cos(pi) + abs(10 - 20))
+                   (3 * 3)
+          v2 = Eql BooleanType
+                   (Or yes no)
+                   (And yes no)
+          v3 = NEq IntegerType
+                   (DivI (10 * 10) 20 - 30)
+                   (50 - 75)
+          v4 = Eql (PairType IntegerType IntegerType)
+                   (PairV (PairType IntegerType IntegerType)
+                         (DivI 20 7)
+                         (ModI 20 7))
+                   (PairV (PairType IntegerType IntegerType)
+                     2 6)
       evaluate v1 EmptyContext `shouldBe` True
       evaluate v2 EmptyContext `shouldBe` False
       evaluate v3 EmptyContext `shouldBe` False

--- a/fractalstream-ui-wx/src/UI/ProjectViewer.hs
+++ b/fractalstream-ui-wx/src/UI/ProjectViewer.hs
@@ -45,7 +45,7 @@ import qualified Data.Set as Set
 import GHC.TypeLits
 import Data.Kind
 import Data.Indexed.Functor
-import Fcf (Exp, Eval, Pure1)
+import Fcf (Exp, Eval)
 
 viewProject :: (forall a. Frame a -> [Menu ()] -> IO ())
             -> UI
@@ -463,7 +463,8 @@ makeWxComplexViewer
     -- that variable changes.
     let usedVars = execState (indexedFoldM gatherUsedVarsInCode cvCode') Set.empty
 
-        gatherUsedVarsInCode :: CodeF '[] (Pure1 Value) Unit et -> State (Set String) ()
+        gatherUsedVarsInCode :: CodeF '[] (FIX ValueF) Unit et
+                             -> State (Set String) ()
         gatherUsedVarsInCode = \case
           Let _ name _ v _ _ -> do
             modify' (Set.delete (symbolVal name))


### PR DESCRIPTION
This PR gets rid of the `Fix` newtype layers in recursive types, using the trick of evaluated first-class-families at the recursive locations in an AST.