### PR TITLE
Update scripting syntax preparation: AST cleanup

### DIFF
--- a/fractalstream-backend-llvm/src/Backend/LLVM/Code.hs
+++ b/fractalstream-backend-llvm/src/Backend/LLVM/Code.hs
@@ -430,27 +430,13 @@ compileCode getExtern = indexedFold @(CtxOp m) @(CodeF '[] (FIX ValueF)) $ \case
 
   NoOp -> pure VoidOp
 
-  Set pf _ t v -> do
-    x <- value_ getExtern v
-    ctx <- ask
-    storeOperand x (withKnownType t (getBinding ctx pf))
-    pure VoidOp
-
-  SetBind pf _ t body -> do
+  Set pf _ t body -> do
     x <- body
     ctx <- ask
     storeOperand x (withKnownType t (getBinding ctx pf))
     pure VoidOp
 
-  Let pf name t v _ body -> do
-    x <- value_ getExtern v
-    ptr <- allocaOp t
-    storeOperand x ptr
-    recallIsAbsent (absentInTail pf) $ do
-      ctx <- Bind name t ptr <$> ask
-      lift (runReaderT body ctx)
-
-  LetBind pf name t val _ body -> do
+  Let pf name t val _ body -> do
     x <- val
     ptr <- allocaOp t
     storeOperand x ptr

--- a/fractalstream-backend-llvm/src/Backend/LLVM/Code.hs
+++ b/fractalstream-backend-llvm/src/Backend/LLVM/Code.hs
@@ -422,7 +422,7 @@ compileCode :: forall m env t
             => (String -> Operand)
             -> Code '[] env t
             -> ReaderT (Context OperandPtr env) m (Op t)
-compileCode getExtern = indexedFold @(CtxOp m) @(CodeF '[] (FIX ValueF)) $ \case
+compileCode getExtern = indexedFold @(CtxOp m) @(CodeF '[]) $ \case
 
   Block _ body end -> sequence_ body >> end
 

--- a/fractalstream-core/src/Language/Code/InterpretIO.hs
+++ b/fractalstream-core/src/Language/Code/InterpretIO.hs
@@ -113,14 +113,8 @@ interpretToIO_ :: forall effs env t s
                -> StateT (Context IORefTypeOfBinding env, s) IO (HaskellType t)
 interpretToIO_ handlers =
   indexedFold @(ScalarIORefMWith s) $ \case
-    Let pf name vt v _ body -> recallIsAbsent (absentInTail pf) $ do
-      (ctxRef, s) <- get
-      value <- eval v
-      valueRef <- lift (newIORef value)
-      let ctxRef' = Bind name vt valueRef ctxRef
-      lift (evalStateT body (ctxRef', s))
 
-    LetBind pf name tv vc _ body -> recallIsAbsent (absentInTail pf) $ do
+    Let pf name tv vc _ body -> recallIsAbsent (absentInTail pf) $ do
       (ctxRef, _) <- get
       value <- vc
       valueRef <- lift (newIORef value)
@@ -128,11 +122,7 @@ interpretToIO_ handlers =
       s <- snd <$> get
       lift (evalStateT body (ctxRef', s))
 
-    Set pf name ty v -> do
-      value <- eval v
-      update pf name ty value
-
-    SetBind pf name tv vc -> do
+    Set pf name tv vc -> do
       value <- vc
       update pf name tv value
 

--- a/fractalstream-core/src/Language/Code/Parser.hs
+++ b/fractalstream-core/src/Language/Code/Parser.hs
@@ -228,7 +228,7 @@ pSet effs env splices = dbg "set" $ do
         Absent' _ -> mzero
         Found' t pf -> do
           v <- nest (parseValueFromTokens env splices t toks)
-          withEnvironment env (pure (Set pf name t v))
+          withEnvironment env (pure (Set pf name t (Pure t v)))
 
   pBind n = do
     -- Figure out what type the RHS should have, and try to parse some
@@ -238,7 +238,7 @@ pSet effs env splices = dbg "set" $ do
         Absent' _ -> mzero
         Found' t pf -> do
           code <- pCode effs env splices t
-          withEnvironment env (pure (SetBind pf name t code))
+          withEnvironment env (pure (Set pf name t code))
 
 -- | Variable initialization
 pVar :: forall effs env splices t
@@ -283,7 +283,7 @@ pVarValue eps env splices t pf name vt = do
     -- peek at the next token, which should be a dedent; we should have parsed the
     -- remainder of the current scope's block.
     lookAhead (tok_ Dedent)
-    pure (Let pf' name vt v t (Block t body final))
+    pure (Let pf' name vt (Pure vt v) t (Block t body final))
 
 pVarCode  :: forall effs env splices t ty name
            . KnownSymbol name
@@ -309,7 +309,7 @@ pVarCode eps env splices t pf name vt = do
     -- peek at the next token, which should be a dedent; we should have parsed the
     -- remainder of the current scope's block.
     lookAhead (tok_ Dedent)
-    pure (LetBind pf' name vt c t (Block t body final))
+    pure (Let pf' name vt c t (Block t body final))
 
 
 -- | Parse type name

--- a/fractalstream-core/src/Language/Code/Simulator.hs
+++ b/fractalstream-core/src/Language/Code/Simulator.hs
@@ -44,15 +44,8 @@ simulate :: forall effs env t s
          -> Code effs env t
          -> State (Context HaskellTypeOfBinding env, s) (HaskellType t)
 simulate handlers = indexedFold @(HaskellTypeM s) $ \case
-  Let pf name vt v _ body -> recallIsAbsent (absentInTail pf) $ do
-    (ctx, s) <- get
-    value <- eval v
-    let ctx' = Bind name vt value ctx
-        (result, (Bind _ _ _ ctx'', s'')) = runState body (ctx', s)
-    put (ctx'', s'')
-    pure result
 
-  LetBind pf name tv vc _tr body -> recallIsAbsent (absentInTail pf) $ do
+  Let pf name tv vc _tr body -> recallIsAbsent (absentInTail pf) $ do
     (ctx, s) <- get
     value <- vc
     let ctx' = Bind name tv value ctx
@@ -60,11 +53,7 @@ simulate handlers = indexedFold @(HaskellTypeM s) $ \case
     put (ctx'', s'')
     pure result
 
-  Set pf name ty v -> do
-    result <- eval v
-    update pf name ty result
-
-  SetBind pf name tv vc -> do
+  Set pf name tv vc -> do
     result <- vc
     update pf name tv result
 

--- a/fractalstream-ui-wx/src/UI/ProjectViewer.hs
+++ b/fractalstream-ui-wx/src/UI/ProjectViewer.hs
@@ -466,12 +466,8 @@ makeWxComplexViewer
         gatherUsedVarsInCode :: CodeF '[] (FIX ValueF) Unit et
                              -> State (Set String) ()
         gatherUsedVarsInCode = \case
-          Let _ name _ v _ _ -> do
-            modify' (Set.delete (symbolVal name))
-            gatherUsedVars v
-          LetBind _ name _ _ _ _ -> modify' (Set.delete (symbolVal name))
-          Set _ _ _ v -> gatherUsedVars v
-          SetBind{} -> pure ()
+          Let _ name _ _ _ _ -> modify' (Set.delete (symbolVal name))
+          Set{} -> pure ()
           Call{} -> pure ()
           Block{} -> pure ()
           Pure _ v -> gatherUsedVars v

--- a/fractalstream-ui-wx/src/UI/ProjectViewer.hs
+++ b/fractalstream-ui-wx/src/UI/ProjectViewer.hs
@@ -463,7 +463,7 @@ makeWxComplexViewer
     -- that variable changes.
     let usedVars = execState (indexedFoldM gatherUsedVarsInCode cvCode') Set.empty
 
-        gatherUsedVarsInCode :: CodeF '[] (FIX ValueF) Unit et
+        gatherUsedVarsInCode :: CodeF '[] Unit et
                              -> State (Set String) ()
         gatherUsedVarsInCode = \case
           Let _ name _ _ _ _ -> modify' (Set.delete (symbolVal name))


### PR DESCRIPTION
- Removed the `value` argument to `CodeF`, which was always instantiated at `FIX ValueF`! 
- Removed the `Let` and `Set` constructors for `CodeF`, and renamed `LetBind` / `SetBind` to `Let` / `Set`. The old pure versions of `Let` / `Set` can be recovered from the new ones by applying `Pure`.