### PR TITLE
Add allocator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ cabal.config
 *.aux
 FractalStream.app/
 cabal-macosx-0.2.3/
+
+.DS_Store

--- a/examples/external_rays.yaml
+++ b/examples/external_rays.yaml
@@ -210,7 +210,7 @@ viewers:
                   R : ℝ ⭠ escape_radius
 
                   theta : ℝ ⭠ p / q
-                  z ⭠ R e^{2 π 𝑖 theta}
+                  z : ℂ ⭠ R e^{2 π 𝑖 theta}
 
                   dist : ℝ ⭠ error
 

--- a/fractalstream-backend-llvm/src/Backend.hs
+++ b/fractalstream-backend-llvm/src/Backend.hs
@@ -1,10 +1,14 @@
 module Backend
   ( withBackend
+  , module Actor.Viewer   -- re-export Backend, ToolRunnerFactory, etc.
   ) where
 
 import Actor.Viewer
 import Backend.LLVM
 
-withBackend :: (ViewerCompiler -> IO a) -> IO a
+withBackend :: (Backend -> IO a) -> IO a
 withBackend action = withJIT $ \jit ->
-  action (ViewerCompiler (withJittedViewer jit))
+  action Backend
+    { bViewerCompiler    = ViewerCompiler (withJittedViewer jit)
+    , bToolRunnerFactory = defaultToolRunnerFactory
+    }

--- a/fractalstream-backend-llvm/src/Backend.hs
+++ b/fractalstream-backend-llvm/src/Backend.hs
@@ -11,4 +11,5 @@ withBackend action = withJIT $ \jit ->
   action Backend
     { bViewerCompiler    = ViewerCompiler (withJittedViewer jit)
     , bToolRunnerFactory = defaultToolRunnerFactory
+    , bToolRunner        = llvmToolRunner jit
     }

--- a/fractalstream-backend-llvm/src/Backend/LLVM.hs
+++ b/fractalstream-backend-llvm/src/Backend/LLVM.hs
@@ -33,6 +33,7 @@ import Foreign.LibFFI
 import Foreign.C.Types
 
 import Backend.LLVM.Code
+import Backend.LLVM.Operand (listNodeStride)
 
 import Language.Value
 import Language.Value.Evaluator (HaskellValue)
@@ -127,10 +128,57 @@ toFFIArg _ t v = case t of
     c <- mallocArray 3
     pokeArray c [r,g,b]
     pure (argPtr c, free c)
-  ListType _ -> pure (argInt32 0, pure ())
+  ListType itemTy -> do
+    (headPtr, cleanup) <- buildListBuffer itemTy v
+    pure (argPtr headPtr, cleanup)
   TextType -> pure (argInt32 0, pure ())
   BooleanType -> pure (argInt8 (if v then 1 else 0), pure ())
   _ -> error ("todo: toFFIArg " ++ showType t)
+
+-- | Allocate and populate a contiguous buffer of linked-list nodes for a
+-- Haskell list.  Returns the head pointer (null for empty) and a cleanup action.
+-- Node layout (stride = listNodeStride itemTy):
+--   bytes 0-7:  next pointer (null = end of list)
+--   bytes 8+:   element data
+buildListBuffer :: TypeProxy t -> [HaskellType t] -> IO (Ptr Word8, IO ())
+buildListBuffer _      []    = pure (nullPtr, pure ())
+buildListBuffer itemTy items = do
+  let n      = length items
+      stride = listNodeStride itemTy
+  buf <- mallocBytes (n * stride) :: IO (Ptr Word8)
+  forM_ (zip [0 .. n - 1] items) $ \(i, item) -> do
+    let nodeBase = buf `plusPtr` (i * stride)
+        nextRaw  = if i == n - 1
+                   then nullPtr
+                   else buf `plusPtr` ((i + 1) * stride) :: Ptr Word8
+    poke (castPtr nodeBase :: Ptr (Ptr Word8)) nextRaw
+    pokeListElem itemTy (nodeBase `plusPtr` 8) item
+  pure (buf, free buf)
+
+-- | Write element data for a single list node at the given byte address.
+-- Returns an optional cleanup action for recursively allocated sub-lists.
+pokeListElem :: TypeProxy t -> Ptr Word8 -> HaskellType t -> IO ()
+pokeListElem t ptr item = case t of
+  BooleanType -> poke (castPtr ptr :: Ptr Word8)
+                      (if item then 1 else 0 :: Word8)
+  IntegerType -> poke (castPtr ptr :: Ptr Int32)
+                      (fromIntegral item :: Int32)
+  RealType    -> poke (castPtr ptr :: Ptr Double) item
+  ComplexType -> do
+    let x :+ y = item
+    poke (castPtr ptr              :: Ptr Double) x
+    poke (castPtr (ptr `plusPtr` 8) :: Ptr Double) y
+  ColorType   -> do
+    let (r, g, b) = colorToRGB item
+    poke ptr r
+    poke (ptr `plusPtr` 1) g
+    poke (ptr `plusPtr` 2) b
+  ListType itemTy' -> do
+    -- Nested list: recursively build and store the head pointer.
+    (headPtr, _cleanup) <- buildListBuffer itemTy' item
+    -- Note: _cleanup leaks for now; nested lists are uncommon.
+    poke (castPtr ptr :: Ptr (Ptr Word8)) headPtr
+  _ -> pure ()  -- unsupported element types: leave zeroed
 
 fromFFIRetArg :: TypeProxy ty
               -> Ptr Double
@@ -265,6 +313,8 @@ withJittedViewer (dylib, session, compileLayer, nextId) mPrepScript code0 action
                 Right is -> forM_ is (\i -> putStrLn ("  " ++ showIntel i))
 
             let fn = castPtrToFunPtr (wordPtrToPtr kernelFn)
+                -- 1 MB arena per tile call, reset per subsample inside the kernel.
+                arenaCapacity = 1024 * 1024 :: Int
             action $ ViewerFunction $ \ViewerArgs{..} -> do
               (colorArg, colorFree) <- toFFIArg (Proxy @"color") ColorType grey
               (args, frees) <- unzip <$> fromContextM toFFIArg vaArgs
@@ -273,6 +323,7 @@ withJittedViewer (dylib, session, compileLayer, nextId) mPrepScript code0 action
                   h = fromIntegral vaHeight :: Int
                   (x0, y0) = vaPoint
                   (dx, dy) = vaStep
+              arena <- mallocBytes arenaCapacity :: IO (Ptr Word8)
               withPrepArrays prepEnvProxy nPixels $ \prepPtrs -> do
                 -- Haskell prep pass: populate prep arrays before LLVM kernel
                 case mPrepScript of
@@ -293,11 +344,13 @@ withJittedViewer (dylib, session, compileLayer, nextId) mPrepScript code0 action
                           (Map.empty, iorefs)
                         writePrepOutputsFromMap prepEnvProxy prepPtrs lastVals
                           (row * w + col)
-                -- Call the LLVM kernel with prep arrays passed as raw pointers
+                -- Call the LLVM kernel with the arena + prep arrays as raw pointers
                 let fullArgs = argPtr   vaBuffer
                              : argInt32 vaWidth
                              : argInt32 vaHeight
                              : argInt32 vaSubsamples
+                             : argPtr   arena
+                             : argInt32 (fromIntegral arenaCapacity)
                              : argCDouble (CDouble $ fst vaPoint)
                              : argCDouble (CDouble $ snd vaPoint)
                              : argCDouble (CDouble $ fst vaStep)
@@ -305,6 +358,7 @@ withJittedViewer (dylib, session, compileLayer, nextId) mPrepScript code0 action
                              : colorArg
                              : args ++ map argPtr prepPtrs
                 callFFI fn retVoid fullArgs
+              free arena
               sequence_ (colorFree : frees)
 
 {-

--- a/fractalstream-backend-llvm/src/Backend/LLVM.hs
+++ b/fractalstream-backend-llvm/src/Backend/LLVM.hs
@@ -30,7 +30,7 @@ import qualified LLVM.Relocation as Reloc
 import Control.Concurrent (getNumCapabilities)
 import Control.Concurrent.Chan
 import Control.Concurrent.MVar
-import Control.Exception (bracket)
+import Control.Exception (bracket, finally)
 
 import Foreign.LibFFI
 import Foreign.C.Types
@@ -271,7 +271,7 @@ withJittedViewer :: forall env t. (MissingViewerArgs env, KnownEnvironment env)
                  -> Maybe (PrepScript env)
                  -> Code (ViewerEnv env)
                  -> (ViewerFunction env -> IO t) -> IO t
-withJittedViewer (dylib, session, compileLayer, nextId) mPrepScript code0 action = do
+withJittedViewer (dylib, session, compileLayer, nextId, arenaPool) mPrepScript code0 action = do
   -- Do some basic AST-level optimizations first
   let code = transformValues (integerPowers . avoidSqrt) code0
   name <- modifyMVar nextId (\n -> pure (n + 1, "kernel_" ++ show n))
@@ -316,15 +316,12 @@ withJittedViewer (dylib, session, compileLayer, nextId) mPrepScript code0 action
                 Right is -> forM_ is (\i -> putStrLn ("  " ++ showIntel i))
 
             let fn = castPtrToFunPtr (wordPtrToPtr kernelFn)
-                -- 1 MB arena per worker, reset per subsample inside the kernel.
-                arenaCapacity = 1024 * 1024 :: Int
 
-            -- Allocate a fixed pool of arenas (one per capability)
-            numWorkers <- getNumCapabilities
-            arenas <- replicateM numWorkers (mallocBytes arenaCapacity :: IO (Ptr Word8))
-            arenaPool <- newChan
-            mapM_ (writeChan arenaPool) arenas
-            result <- action $ ViewerFunction $ \ViewerArgs{..} ->
+            -- Borrow an arena from the session-wide pool for the duration of each
+            -- kernel call; bracket returns it even if AsyncCancelled is thrown.
+            -- The pool (and the arena lifetime) is owned by withJIT, not here,
+            -- because rendering outlives this action (see LLVMJit).
+            action $ ViewerFunction $ \ViewerArgs{..} ->
               bracket (readChan arenaPool) (writeChan arenaPool) $ \arena -> do
                 (colorArg, colorFree) <- toFFIArg (Proxy @"color") ColorType grey
                 (args, frees) <- unzip <$> fromContextM toFFIArg vaArgs
@@ -368,8 +365,6 @@ withJittedViewer (dylib, session, compileLayer, nextId) mPrepScript code0 action
                                : args ++ map argPtr prepPtrs
                   callFFI fn retVoid fullArgs
                 sequence_ (colorFree : frees)
-            mapM_ free arenas
-            pure result
 
 {-
 -- This is only used in tests
@@ -418,7 +413,15 @@ withCompiledCode env code run = do
                 run (mkJX fn)
 -}
 
-type LLVMJit = (JITDylib, ExecutionSession, IRCompileLayer, MVar Int)
+-- | 1 MB arena per worker, reset per subsample inside the kernel.
+arenaCapacity :: Int
+arenaCapacity = 1024 * 1024
+
+-- | The arena pool lives for the whole JIT session: the JIT'd kernels stay
+-- resident until the session is torn down, and rendering runs on the wx event
+-- loop *after* each 'withJittedViewer' action returns, so the arenas must
+-- outlive any single viewer compile (and be shared across viewers).
+type LLVMJit = (JITDylib, ExecutionSession, IRCompileLayer, MVar Int, Chan (Ptr Word8))
 
 withJIT :: (LLVMJit -> IO t) -> IO t
 withJIT action = do
@@ -431,7 +434,20 @@ withJIT action = do
       compileLayer <- createIRCompileLayer session linker tm
       addDynamicLibrarySearchGeneratorForCurrentProcess compileLayer dylib
       nextId <- newMVar 0
-      action (dylib, session, compileLayer, nextId)
+
+      -- Fixed pool of arenas (one per capability), shared by all viewers.
+      numWorkers <- getNumCapabilities
+      arenas <- replicateM numWorkers (mallocBytes arenaCapacity :: IO (Ptr Word8))
+      arenaPool <- newChan
+      mapM_ (writeChan arenaPool) arenas
+      -- On teardown, reading all arenas back blocks until every in-flight kernel
+      -- call has returned its arena (each call holds one for exactly its
+      -- duration via bracket below) and leaves the pool empty so none can start
+      -- -- so freeing them and unmapping the session afterwards is safe.
+      let drainAndFreeArenas =
+            replicateM numWorkers (readChan arenaPool) >>= mapM_ free
+      action (dylib, session, compileLayer, nextId, arenaPool)
+        `finally` drainAndFreeArenas
 
 withHostTargetMachine' :: (TargetMachine -> IO a) -> IO a
 withHostTargetMachine' f = do

--- a/fractalstream-backend-llvm/src/Backend/LLVM.hs
+++ b/fractalstream-backend-llvm/src/Backend/LLVM.hs
@@ -141,16 +141,29 @@ toFFIArg _ t v = case t of
   _ -> error ("todo: toFFIArg " ++ showType t)
 
 -- | Like 'toFFIArg', but for tool handlers, which may /set/ config variables.
--- Complex and Color values are passed as pointers and bound in/out by the
--- compiled kernel, so the caller's buffer holds the final value after the call.
--- The returned write-back action reads that buffer and, if the value changed
--- and the argument is settable, propagates it back to the host.  Other types
--- are passed by value (no write-back yet).
+-- Scalar values (Integer/Real/Boolean/Complex/Color) are passed as pointers and
+-- bound in/out by the compiled kernel, so the caller's cell holds the final
+-- value after the call.  The returned write-back action reads that cell and, if
+-- the value changed and the argument is settable, propagates it back to the
+-- host.  Lists and text are passed by value (no write-back).  The set of in/out
+-- types must match 'Backend.LLVM.Code.toolInOut'.
 toFFIArgInOut :: TypeProxy ty
               -> EventArgument ty
               -> HaskellType ty
               -> IO (Arg, IO () {- free -}, IO () {- write-back -})
 toFFIArgInOut t earg v = case t of
+  IntegerType -> do
+    p <- malloc :: IO (Ptr Int32)
+    poke p (fromIntegral v)
+    pure (argPtr p, free p, peek p >>= \v' -> setBack IntegerType (fromIntegral v'))
+  RealType -> do
+    p <- malloc :: IO (Ptr Double)
+    poke p v
+    pure (argPtr p, free p, peek p >>= \v' -> setBack RealType v')
+  BooleanType -> do
+    p <- malloc :: IO (Ptr Word8)
+    poke p (if v then 1 else 0)
+    pure (argPtr p, free p, peek p >>= \w -> setBack BooleanType (w /= 0))
   ComplexType -> do
     let x :+ y = v
     z <- mallocArray 2
@@ -462,62 +475,68 @@ withDrawVTablePtrs sink action = do
 -- commands routed back to the given sink.  Compiles once per invocation for now.
 compiledToolExec :: LLVMJit -> DrawSink -> ToolExec
 compiledToolExec (dylib, session, compileLayer, nextId, arenaPool) sink =
-  \envp ctx code -> snapshotEventArgs ctx >>= \case
-    Nothing -> pure ()
-    Just haskArgs ->
-      withDrawVTablePtrs sink $ \(clearFP, strokeFP, fillFP, pointFP, lineFP, circleFP, rectFP) ->
-      bracket (readChan arenaPool) (writeChan arenaPool) $ \arena ->
-      allocaBytes 1 $ \overflowPtr -> do
-        poke overflowPtr (0 :: Word8)
-        (envArgs, envFrees, envWriteBacks) <-
-          unzip3 <$> fromContextM (\_ ty (earg, v) -> toFFIArgInOut ty earg v)
-                                  (zipContext ctx haskArgs)
-        name <- modifyMVar nextId (\n -> pure (n + 1, "tool_" ++ show n))
+  \envp code -> do
+    -- Compile the handler ONCE, when the dispatcher is built.  OrcJIT's
+    -- 'addModule' hands a clone of the module to the session-wide JIT, so the
+    -- resulting function pointer stays valid after these brackets close.
+    name <- modifyMVar nextId (\n -> pure (n + 1, "tool_" ++ show n))
 
-        -- Same AST pre-pass as viewers: turn constant-exponent powers (e.g. z²)
-        -- into multiplications instead of generic exp/log complex powers, which
-        -- otherwise lose precision and shift a Newton iteration off course.
-        let code' = transformValues (integerPowers . avoidSqrt) code
+    -- Same AST pre-pass as viewers: turn constant-exponent powers (e.g. z²)
+    -- into multiplications instead of generic exp/log complex powers, which
+    -- otherwise lose precision and shift a Newton iteration off course.
+    let code' = transformValues (integerPowers . avoidSqrt) code
 
-        m <- either error pure (compileToolHandler envp (fromString name) code')
-        withContext $ \llctx ->
-          withModuleFromAST llctx m $ \md -> do
-            let pm = CuratedPassSetSpec
-                     { optLevel = Just 2
-                     , sizeLevel = Nothing
-                     , unitAtATime = Nothing
-                     , simplifyLibCalls = Just True
-                     , loopVectorize = Just True
-                     , superwordLevelParallelismVectorize = Nothing
-                     , useInlinerWithThreshold = Nothing
-                     , dataLayout = Nothing
-                     , targetLibraryInfo = Nothing
-                     , targetMachine = Nothing
-                     }
-            _ <- withPassManager pm (`runPassManager` md)
-            withClonedThreadSafeModule md $ \tsm -> do
-              addModule tsm dylib compileLayer
-              lookupSymbol session compileLayer dylib (fromString name) >>= \case
-                Left err -> error ("error JITing tool handler: " ++ show err)
-                Right (JITSymbol fnPtr _) -> do
-                  let fn = castPtrToFunPtr (wordPtrToPtr fnPtr)
-                      fullArgs =
-                        [ argPtr (castFunPtrToPtr clearFP)
-                        , argPtr (castFunPtrToPtr strokeFP)
-                        , argPtr (castFunPtrToPtr fillFP)
-                        , argPtr (castFunPtrToPtr pointFP)
-                        , argPtr (castFunPtrToPtr lineFP)
-                        , argPtr (castFunPtrToPtr circleFP)
-                        , argPtr (castFunPtrToPtr rectFP)
-                        , argPtr arena
-                        , argInt32 (fromIntegral arenaCapacity)
-                        , argPtr overflowPtr ]
-                        ++ envArgs
-                  callFFI fn retVoid fullArgs
-                  -- Propagate any config-variable Sets back to the host
-                  -- (e.g. the Select tool sets the coordinate), then free.
-                  sequence_ envWriteBacks
-                  sequence_ envFrees
+    m <- either error pure (compileToolHandler envp (fromString name) code')
+    fn <- withContext $ \llctx ->
+      withModuleFromAST llctx m $ \md -> do
+        let pm = CuratedPassSetSpec
+                 { optLevel = Just 2
+                 , sizeLevel = Nothing
+                 , unitAtATime = Nothing
+                 , simplifyLibCalls = Just True
+                 , loopVectorize = Just True
+                 , superwordLevelParallelismVectorize = Nothing
+                 , useInlinerWithThreshold = Nothing
+                 , dataLayout = Nothing
+                 , targetLibraryInfo = Nothing
+                 , targetMachine = Nothing
+                 }
+        _ <- withPassManager pm (`runPassManager` md)
+        withClonedThreadSafeModule md $ \tsm -> do
+          addModule tsm dylib compileLayer
+          lookupSymbol session compileLayer dylib (fromString name) >>= \case
+            Left err -> error ("error JITing tool handler: " ++ show err)
+            Right (JITSymbol fnPtr _) ->
+              pure (castPtrToFunPtr (wordPtrToPtr fnPtr) :: FunPtr ())
+
+    -- The per-event invoker: snapshot args, marshal, call, write back.
+    pure $ \ctx -> snapshotEventArgs ctx >>= \case
+      Nothing -> pure ()
+      Just haskArgs ->
+        withDrawVTablePtrs sink $ \(clearFP, strokeFP, fillFP, pointFP, lineFP, circleFP, rectFP) ->
+        bracket (readChan arenaPool) (writeChan arenaPool) $ \arena ->
+        allocaBytes 1 $ \overflowPtr -> do
+          poke overflowPtr (0 :: Word8)
+          (envArgs, envFrees, envWriteBacks) <-
+            unzip3 <$> fromContextM (\_ ty (earg, v) -> toFFIArgInOut ty earg v)
+                                    (zipContext ctx haskArgs)
+          let fullArgs =
+                [ argPtr (castFunPtrToPtr clearFP)
+                , argPtr (castFunPtrToPtr strokeFP)
+                , argPtr (castFunPtrToPtr fillFP)
+                , argPtr (castFunPtrToPtr pointFP)
+                , argPtr (castFunPtrToPtr lineFP)
+                , argPtr (castFunPtrToPtr circleFP)
+                , argPtr (castFunPtrToPtr rectFP)
+                , argPtr arena
+                , argInt32 (fromIntegral arenaCapacity)
+                , argPtr overflowPtr ]
+                ++ envArgs
+          callFFI fn retVoid fullArgs
+          -- Propagate any config-variable Sets back to the host
+          -- (e.g. the Select tool sets the coordinate), then free.
+          sequence_ envWriteBacks
+          sequence_ envFrees
 
 -- | A 'ToolRunner' that JIT-compiles tool event handlers via this JIT session.
 llvmToolRunner :: LLVMJit -> ToolRunner

--- a/fractalstream-backend-llvm/src/Backend/LLVM.hs
+++ b/fractalstream-backend-llvm/src/Backend/LLVM.hs
@@ -8,6 +8,7 @@ module Backend.LLVM
   -- , withCompiledCode
   , withJIT
   , withJittedViewer
+  , llvmToolRunner
   , runJX
   , type JX
   , mkKernelFun
@@ -43,8 +44,9 @@ import Language.Value.Evaluator (HaskellValue)
 import Language.Value.Transform
 import Language.Code
 import Language.Code.InterpretIO (interpretToIOWithLastValues, ScalarIORefM)
-import Language.Draw (DrawHandler(..))
+import Language.Draw
 import Actor.Viewer
+import Actor.Event (ToolExec, buildHandlerWith, snapshotEventArgs, EventArgument(..))
 import Data.Color
 
 import Data.IORef (newIORef)
@@ -137,6 +139,41 @@ toFFIArg _ t v = case t of
   TextType -> pure (argInt32 0, pure ())
   BooleanType -> pure (argInt8 (if v then 1 else 0), pure ())
   _ -> error ("todo: toFFIArg " ++ showType t)
+
+-- | Like 'toFFIArg', but for tool handlers, which may /set/ config variables.
+-- Complex and Color values are passed as pointers and bound in/out by the
+-- compiled kernel, so the caller's buffer holds the final value after the call.
+-- The returned write-back action reads that buffer and, if the value changed
+-- and the argument is settable, propagates it back to the host.  Other types
+-- are passed by value (no write-back yet).
+toFFIArgInOut :: TypeProxy ty
+              -> EventArgument ty
+              -> HaskellType ty
+              -> IO (Arg, IO () {- free -}, IO () {- write-back -})
+toFFIArgInOut t earg v = case t of
+  ComplexType -> do
+    let x :+ y = v
+    z <- mallocArray 2
+    pokeArray z [x, y]
+    let writeBack = peekArray 2 z >>= \case
+          [x', y'] -> setBack ComplexType (x' :+ y')
+          _        -> pure ()
+    pure (argPtr z, free z, writeBack)
+  ColorType -> do
+    let (r, g, b) = colorToRGB v
+    c <- mallocArray 3
+    pokeArray c [r, g, b]
+    let writeBack = peekArray 3 c >>= \case
+          [r', g', b'] -> setBack ColorType (rgbToColor (r', g', b'))
+          _            -> pure ()
+    pure (argPtr c, free c, writeBack)
+  _ -> do
+    (arg, free') <- toFFIArg (Proxy @"tool-arg") t v
+    pure (arg, free', pure ())
+ where
+  setBack ty newV = case argSetValue earg of
+    Just setter | Scalar ty v /= Scalar ty newV -> setter ty newV
+    _ -> pure ()
 
 -- | Allocate and populate a contiguous buffer of linked-list nodes for a
 -- Haskell list.  Returns the head pointer (null for empty) and a cleanup action.
@@ -365,6 +402,127 @@ withJittedViewer (dylib, session, compileLayer, nextId, arenaPool) mPrepScript c
                                : args ++ map argPtr prepPtrs
                   callFFI fn retVoid fullArgs
                 sequence_ (colorFree : frees)
+
+------------------------------------------------------------------------
+-- Compiled tools
+------------------------------------------------------------------------
+
+foreign import ccall "wrapper"
+  wrapClear :: IO () -> IO (FunPtr (IO ()))
+foreign import ccall "wrapper"
+  wrapColor3 :: (Word8 -> Word8 -> Word8 -> IO ())
+             -> IO (FunPtr (Word8 -> Word8 -> Word8 -> IO ()))
+foreign import ccall "wrapper"
+  wrapPoint :: (CDouble -> CDouble -> IO ())
+            -> IO (FunPtr (CDouble -> CDouble -> IO ()))
+foreign import ccall "wrapper"
+  wrapLine :: (CDouble -> CDouble -> CDouble -> CDouble -> IO ())
+           -> IO (FunPtr (CDouble -> CDouble -> CDouble -> CDouble -> IO ()))
+foreign import ccall "wrapper"
+  wrapCircle :: (Word8 -> CDouble -> CDouble -> CDouble -> IO ())
+             -> IO (FunPtr (Word8 -> CDouble -> CDouble -> CDouble -> IO ()))
+foreign import ccall "wrapper"
+  wrapRect :: (Word8 -> CDouble -> CDouble -> CDouble -> CDouble -> IO ())
+           -> IO (FunPtr (Word8 -> CDouble -> CDouble -> CDouble -> CDouble -> IO ()))
+
+-- | Build the seven C callbacks for a 'DrawSink', run the action with them, and
+-- free them afterwards.
+withDrawVTablePtrs
+  :: DrawSink
+  -> ( ( FunPtr (IO ())
+       , FunPtr (Word8 -> Word8 -> Word8 -> IO ())
+       , FunPtr (Word8 -> Word8 -> Word8 -> IO ())
+       , FunPtr (CDouble -> CDouble -> IO ())
+       , FunPtr (CDouble -> CDouble -> CDouble -> CDouble -> IO ())
+       , FunPtr (Word8 -> CDouble -> CDouble -> CDouble -> IO ())
+       , FunPtr (Word8 -> CDouble -> CDouble -> CDouble -> CDouble -> IO ()) )
+       -> IO a )
+  -> IO a
+withDrawVTablePtrs sink action = do
+  clearFP  <- wrapClear  (dsClear sink)
+  strokeFP <- wrapColor3 (\r g b -> dsStroke sink (rgbToColor (r, g, b)))
+  fillFP   <- wrapColor3 (\r g b -> dsFill sink (rgbToColor (r, g, b)))
+  pointFP  <- wrapPoint  (\x y -> dsPoint sink (realToFrac x, realToFrac y))
+  lineFP   <- wrapLine   (\x1 y1 x2 y2 ->
+                            dsLine sink (realToFrac x1, realToFrac y1)
+                                        (realToFrac x2, realToFrac y2))
+  circleFP <- wrapCircle (\f r x y ->
+                            dsCircle sink (f /= 0) (realToFrac r)
+                                          (realToFrac x, realToFrac y))
+  rectFP   <- wrapRect   (\f x1 y1 x2 y2 ->
+                            dsRect sink (f /= 0) (realToFrac x1, realToFrac y1)
+                                        (realToFrac x2, realToFrac y2))
+  action (clearFP, strokeFP, fillFP, pointFP, lineFP, circleFP, rectFP)
+    `finally` (   freeHaskellFunPtr clearFP  >> freeHaskellFunPtr strokeFP
+               >> freeHaskellFunPtr fillFP   >> freeHaskellFunPtr pointFP
+               >> freeHaskellFunPtr lineFP   >> freeHaskellFunPtr circleFP
+               >> freeHaskellFunPtr rectFP )
+
+-- | Execute a tool event handler by JIT-compiling it and calling it, with draw
+-- commands routed back to the given sink.  Compiles once per invocation for now.
+compiledToolExec :: LLVMJit -> DrawSink -> ToolExec
+compiledToolExec (dylib, session, compileLayer, nextId, arenaPool) sink =
+  \envp ctx code -> snapshotEventArgs ctx >>= \case
+    Nothing -> pure ()
+    Just haskArgs ->
+      withDrawVTablePtrs sink $ \(clearFP, strokeFP, fillFP, pointFP, lineFP, circleFP, rectFP) ->
+      bracket (readChan arenaPool) (writeChan arenaPool) $ \arena ->
+      allocaBytes 1 $ \overflowPtr -> do
+        poke overflowPtr (0 :: Word8)
+        (envArgs, envFrees, envWriteBacks) <-
+          unzip3 <$> fromContextM (\_ ty (earg, v) -> toFFIArgInOut ty earg v)
+                                  (zipContext ctx haskArgs)
+        name <- modifyMVar nextId (\n -> pure (n + 1, "tool_" ++ show n))
+
+        -- Same AST pre-pass as viewers: turn constant-exponent powers (e.g. z²)
+        -- into multiplications instead of generic exp/log complex powers, which
+        -- otherwise lose precision and shift a Newton iteration off course.
+        let code' = transformValues (integerPowers . avoidSqrt) code
+
+        m <- either error pure (compileToolHandler envp (fromString name) code')
+        withContext $ \llctx ->
+          withModuleFromAST llctx m $ \md -> do
+            let pm = CuratedPassSetSpec
+                     { optLevel = Just 2
+                     , sizeLevel = Nothing
+                     , unitAtATime = Nothing
+                     , simplifyLibCalls = Just True
+                     , loopVectorize = Just True
+                     , superwordLevelParallelismVectorize = Nothing
+                     , useInlinerWithThreshold = Nothing
+                     , dataLayout = Nothing
+                     , targetLibraryInfo = Nothing
+                     , targetMachine = Nothing
+                     }
+            _ <- withPassManager pm (`runPassManager` md)
+            withClonedThreadSafeModule md $ \tsm -> do
+              addModule tsm dylib compileLayer
+              lookupSymbol session compileLayer dylib (fromString name) >>= \case
+                Left err -> error ("error JITing tool handler: " ++ show err)
+                Right (JITSymbol fnPtr _) -> do
+                  let fn = castPtrToFunPtr (wordPtrToPtr fnPtr)
+                      fullArgs =
+                        [ argPtr (castFunPtrToPtr clearFP)
+                        , argPtr (castFunPtrToPtr strokeFP)
+                        , argPtr (castFunPtrToPtr fillFP)
+                        , argPtr (castFunPtrToPtr pointFP)
+                        , argPtr (castFunPtrToPtr lineFP)
+                        , argPtr (castFunPtrToPtr circleFP)
+                        , argPtr (castFunPtrToPtr rectFP)
+                        , argPtr arena
+                        , argInt32 (fromIntegral arenaCapacity)
+                        , argPtr overflowPtr ]
+                        ++ envArgs
+                  callFFI fn retVoid fullArgs
+                  -- Propagate any config-variable Sets back to the host
+                  -- (e.g. the Select tool sets the coordinate), then free.
+                  sequence_ envWriteBacks
+                  sequence_ envFrees
+
+-- | A 'ToolRunner' that JIT-compiles tool event handlers via this JIT session.
+llvmToolRunner :: LLVMJit -> ToolRunner
+llvmToolRunner jit = ToolRunner $ \sink layer ctx handlers ->
+  buildHandlerWith (compiledToolExec jit (sink layer)) ctx handlers
 
 {-
 -- This is only used in tests

--- a/fractalstream-backend-llvm/src/Backend/LLVM.hs
+++ b/fractalstream-backend-llvm/src/Backend/LLVM.hs
@@ -27,7 +27,10 @@ import LLVM.Linking
 import qualified LLVM.CodeModel as CodeModel
 import qualified LLVM.CodeGenOpt as CodeGenOpt
 import qualified LLVM.Relocation as Reloc
+import Control.Concurrent (getNumCapabilities)
+import Control.Concurrent.Chan
 import Control.Concurrent.MVar
+import Control.Exception (bracket)
 
 import Foreign.LibFFI
 import Foreign.C.Types
@@ -313,53 +316,60 @@ withJittedViewer (dylib, session, compileLayer, nextId) mPrepScript code0 action
                 Right is -> forM_ is (\i -> putStrLn ("  " ++ showIntel i))
 
             let fn = castPtrToFunPtr (wordPtrToPtr kernelFn)
-                -- 1 MB arena per tile call, reset per subsample inside the kernel.
+                -- 1 MB arena per worker, reset per subsample inside the kernel.
                 arenaCapacity = 1024 * 1024 :: Int
-            action $ ViewerFunction $ \ViewerArgs{..} -> do
-              (colorArg, colorFree) <- toFFIArg (Proxy @"color") ColorType grey
-              (args, frees) <- unzip <$> fromContextM toFFIArg vaArgs
-              let nPixels = fromIntegral vaWidth * fromIntegral vaHeight :: Int
-                  w = fromIntegral vaWidth  :: Int
-                  h = fromIntegral vaHeight :: Int
-                  (x0, y0) = vaPoint
-                  (dx, dy) = vaStep
-              arena <- mallocBytes arenaCapacity :: IO (Ptr Word8)
-              withPrepArrays prepEnvProxy nPixels $ \prepPtrs -> do
-                -- Haskell prep pass: populate prep arrays before LLVM kernel
-                case mPrepScript of
-                  Nothing -> pure ()
-                  Just (PrepScript _ prepCode) -> do
-                    forM_ (zip [0 .. h - 1] [y0, y0 - dy ..]) $ \(row, y) ->
-                      forM_ (zip [0 .. w - 1] [x0, x0 + dx ..]) $ \(col, x) -> do
-                        let pixelCtx :: Context HaskellValue (ViewerEnv env)
-                            pixelCtx = Bind (Proxy @InternalX)  RealType  x
-                                     $ Bind (Proxy @InternalY)  RealType  y
-                                     $ Bind (Proxy @InternalDX) RealType  dx
-                                     $ Bind (Proxy @InternalDY) RealType  dy
-                                     $ Bind (Proxy @"color")    ColorType grey
-                                     $ vaArgs
-                        iorefs <- mapContextM (\_ _ -> newIORef) pixelCtx
-                        (lastVals, _) <- execStateT
-                          (interpretToIOWithLastValues noPrepDraw prepCode)
-                          (Map.empty, iorefs)
-                        writePrepOutputsFromMap prepEnvProxy prepPtrs lastVals
-                          (row * w + col)
-                -- Call the LLVM kernel with the arena + prep arrays as raw pointers
-                let fullArgs = argPtr   vaBuffer
-                             : argInt32 vaWidth
-                             : argInt32 vaHeight
-                             : argInt32 vaSubsamples
-                             : argPtr   arena
-                             : argInt32 (fromIntegral arenaCapacity)
-                             : argCDouble (CDouble $ fst vaPoint)
-                             : argCDouble (CDouble $ snd vaPoint)
-                             : argCDouble (CDouble $ fst vaStep)
-                             : argCDouble (CDouble $ snd vaStep)
-                             : colorArg
-                             : args ++ map argPtr prepPtrs
-                callFFI fn retVoid fullArgs
-              free arena
-              sequence_ (colorFree : frees)
+
+            -- Allocate a fixed pool of arenas (one per capability)
+            numWorkers <- getNumCapabilities
+            arenas <- replicateM numWorkers (mallocBytes arenaCapacity :: IO (Ptr Word8))
+            arenaPool <- newChan
+            mapM_ (writeChan arenaPool) arenas
+            result <- action $ ViewerFunction $ \ViewerArgs{..} ->
+              bracket (readChan arenaPool) (writeChan arenaPool) $ \arena -> do
+                (colorArg, colorFree) <- toFFIArg (Proxy @"color") ColorType grey
+                (args, frees) <- unzip <$> fromContextM toFFIArg vaArgs
+                let nPixels = fromIntegral vaWidth * fromIntegral vaHeight :: Int
+                    w = fromIntegral vaWidth  :: Int
+                    h = fromIntegral vaHeight :: Int
+                    (x0, y0) = vaPoint
+                    (dx, dy) = vaStep
+                withPrepArrays prepEnvProxy nPixels $ \prepPtrs -> do
+                  -- Haskell prep pass: populate prep arrays before LLVM kernel
+                  case mPrepScript of
+                    Nothing -> pure ()
+                    Just (PrepScript _ prepCode) -> do
+                      forM_ (zip [0 .. h - 1] [y0, y0 - dy ..]) $ \(row, y) ->
+                        forM_ (zip [0 .. w - 1] [x0, x0 + dx ..]) $ \(col, x) -> do
+                          let pixelCtx :: Context HaskellValue (ViewerEnv env)
+                              pixelCtx = Bind (Proxy @InternalX)  RealType  x
+                                       $ Bind (Proxy @InternalY)  RealType  y
+                                       $ Bind (Proxy @InternalDX) RealType  dx
+                                       $ Bind (Proxy @InternalDY) RealType  dy
+                                       $ Bind (Proxy @"color")    ColorType grey
+                                       $ vaArgs
+                          iorefs <- mapContextM (\_ _ -> newIORef) pixelCtx
+                          (lastVals, _) <- execStateT
+                            (interpretToIOWithLastValues noPrepDraw prepCode)
+                            (Map.empty, iorefs)
+                          writePrepOutputsFromMap prepEnvProxy prepPtrs lastVals
+                            (row * w + col)
+                  -- Call the LLVM kernel with the arena + prep arrays as raw pointers
+                  let fullArgs = argPtr   vaBuffer
+                               : argInt32 vaWidth
+                               : argInt32 vaHeight
+                               : argInt32 vaSubsamples
+                               : argPtr   arena
+                               : argInt32 (fromIntegral arenaCapacity)
+                               : argCDouble (CDouble $ fst vaPoint)
+                               : argCDouble (CDouble $ snd vaPoint)
+                               : argCDouble (CDouble $ fst vaStep)
+                               : argCDouble (CDouble $ snd vaStep)
+                               : colorArg
+                               : args ++ map argPtr prepPtrs
+                  callFFI fn retVoid fullArgs
+                sequence_ (colorFree : frees)
+            mapM_ free arenas
+            pure result
 
 {-
 -- This is only used in tests

--- a/fractalstream-backend-llvm/src/Backend/LLVM/Code.hs
+++ b/fractalstream-backend-llvm/src/Backend/LLVM/Code.hs
@@ -601,7 +601,7 @@ compileToolHandler envp name code = runExcept $
         arenaParams    = [ (AST.ptr AST.i8, ParameterName "#arenaPtr")
                          , (AST.i32,        ParameterName "#arenaSize") ]
         overflowParams = [ (AST.ptr AST.i8, ParameterName "#overflowOut") ]
-        params = drawParams ++ arenaParams ++ overflowParams ++ toParameterList envp
+        params = drawParams ++ arenaParams ++ overflowParams ++ toToolParameterList envp
         fnPtrTy rTy aTys = AST.ptr (AST.FunctionType rTy aTys False)
     function name params AST.void $ \allArgs -> do
       getExtern <- getGetExtern
@@ -821,11 +821,30 @@ allocaArg t op = do
   storeOperand x ptr
   pure ptr
 
--- | Bind a tool handler's environment arguments.  Complex and Color values are
--- already passed as pointers, so we bind them in/out (pointing directly at the
--- caller's buffer) so that a 'Set' of a config variable is visible to the host
--- after the call (used for write-back, e.g. the Select tool).  Everything else
--- is bound by value as usual (no write-back yet).
+-- | Scalar tool-handler arguments are passed in/out: the caller hands the
+-- kernel a pointer to a cell, so a 'Set' of a config variable is visible to the
+-- host after the call (write-back; e.g. the Select tool sets a coordinate, or
+-- newton3's \"Move roots\" tool sets @drag_target@).  Lists and text are passed
+-- by value (read-only — no write-back).  This predicate must agree between
+-- 'toToolParameterList' (param types), 'bindToolArg', and the host's marshaller.
+toolInOut :: TypeProxy t -> Bool
+toolInOut = \case
+  IntegerType -> True
+  RealType    -> True
+  BooleanType -> True
+  ComplexType -> True
+  ColorType   -> True
+  _           -> False
+
+-- | Parameter types for a tool handler's environment: in/out types become
+-- pointers; everything else keeps its by-value representation.
+toToolParameterList :: EnvironmentProxy env -> [(AST.Type, ParameterName)]
+toToolParameterList = \case
+  EmptyEnvProxy -> []
+  BindingProxy name t env ->
+    let ty = if toolInOut t then toLLVMPtrType t else toLLVMType t
+    in (ty, ParameterName (fromString (symbolVal name))) : toToolParameterList env
+
 allocaToolArgs :: (MonadModuleBuilder m, MonadIRBuilder m, MonadError String m)
                => EnvironmentProxy env
                -> [Operand]
@@ -836,9 +855,11 @@ allocaToolArgs (BindingProxy name ty env) (op:ops) =
 allocaToolArgs _ _ =
   throwError "internal error: mismatched environment/args counts (tool)"
 
+-- | Bind a tool handler's environment argument.  In/out types receive a pointer
+-- and are bound directly to the caller's cell (so 'Set' writes are visible to
+-- the host); other types are bound by value as usual.
 bindToolArg :: (MonadModuleBuilder m, MonadIRBuilder m, MonadError String m)
             => TypeProxy t -> Operand -> m (PtrOp t)
-bindToolArg ty op = case ty of
-  ComplexType -> typedOperandPtr ComplexType op
-  ColorType   -> typedOperandPtr ColorType op
-  _           -> allocaArg ty op
+bindToolArg ty op
+  | toolInOut ty = typedOperandPtr ty op
+  | otherwise    = allocaArg ty op

--- a/fractalstream-backend-llvm/src/Backend/LLVM/Code.hs
+++ b/fractalstream-backend-llvm/src/Backend/LLVM/Code.hs
@@ -374,9 +374,15 @@ compileRenderer' prepOutputEnv name code = runExcept $
   assertAbsent (Proxy @InternalDY)          (envProxy (Proxy @env)) $
   assertAbsent (Proxy @"color")             (envProxy (Proxy @env)) $
   buildModuleT "compiled rendering kernel" $ do
-    let retParam       = (toLLVMPtrType ColorType, NoParameterName)
-        params         = toParameterList (envProxy (Proxy @(RenderEnv' env)))
-        prepParams     = toPrepParamList prepOutputEnv
+    let retParam     = (toLLVMPtrType ColorType, NoParameterName)
+        allEnvParams = toParameterList (envProxy (Proxy @(RenderEnv' env)))
+        -- RenderEnv' env = blockWidth ': blockHeight ': subsamples ': ViewerEnv env
+        -- First 3 params are the internal render args; the rest are ViewerEnv.
+        (internalRenderParams, viewerEnvParams) = splitAt 3 allEnvParams
+        arenaParams  = [ (AST.ptr AST.i8, ParameterName "#arenaPtr")
+                       , (AST.i32,        ParameterName "#arenaSize") ]
+        params       = internalRenderParams ++ arenaParams ++ viewerEnvParams
+        prepParams   = toPrepParamList prepOutputEnv
         pfX      = bindingEvidence @InternalX   @'RealT  @(ViewerEnv env)
         pfY      = bindingEvidence @InternalY   @'RealT  @(ViewerEnv env)
         pfdX     = bindingEvidence @InternalDX  @'RealT  @(ViewerEnv env)
@@ -384,7 +390,8 @@ compileRenderer' prepOutputEnv name code = runExcept $
         pfOutput = bindingEvidence @"color"     @'ColorT @(ViewerEnv env)
         nViewerEnvArgs = envLength (envProxy (Proxy @(ViewerEnv env)))
     function name (retParam : params ++ prepParams) AST.void $ \allArgs -> do
-      let (retPtr : blockWidthArg : blockHeightArg : subsamplesArg : rest) = allArgs
+      let (retPtr : blockWidthArg : blockHeightArg : subsamplesArg
+                  : arenaPtrArg : arenaSizeArg : rest) = allArgs
           (rawArgs, prepArrayPtrs) = splitAt nViewerEnvArgs rest
       getExtern <- getGetExtern
       mdo
@@ -393,6 +400,12 @@ compileRenderer' prepOutputEnv name code = runExcept $
         blockWidthPtr  <- allocaArg IntegerType blockWidthArg
         blockHeightPtr <- allocaArg IntegerType blockHeightArg
         subsamplesPtr  <- allocaArg IntegerType subsamplesArg
+        -- Arena setup: bumpAlloca tracks the current allocation position.
+        -- arenaEnd is constant = arenaBase + arenaSize.
+        bumpAlloca <- alloca (AST.ptr AST.i8) Nothing 0
+        store bumpAlloca 0 arenaPtrArg
+        arenaEnd <- gep arenaPtrArg [arenaSizeArg]
+        let arenaState = ArenaState bumpAlloca arenaEnd
         args <- allocaArgs (envProxy (Proxy @(ViewerEnv env))) rawArgs
         x0 <- derefOperand (getBinding args pfX)  >>= \case RealOp v -> pure v
         y0 <- derefOperand (getBinding args pfY)  >>= \case RealOp v -> pure v
@@ -441,11 +454,15 @@ compileRenderer' prepOutputEnv name code = runExcept $
           storeOperand (RealOp xVal) (getBinding args pfX)
           storeOperand (RealOp yVal) (getBinding args pfY)
 
+          -- Reset the arena at the start of each subsample so each pixel's
+          -- dynamic list allocations are independent.
+          store bumpAlloca 0 arenaPtrArg
+
           -- Load prep output vars from their flat arrays before the kernel.
           pixelIndex <- load pixelIndexPtr 0
           overwritePrepOutputs prepOutputEnv prepArrayPtrs pixelIndex argMap
 
-          runReaderT (compileCode getExtern code) args
+          runReaderT (compileCode getExtern arenaState code) args
           (cr0, cg0, cb0) <- case getBinding args pfOutput of
             PtrOp (ColorOp outputR outputG outputB) ->
               (,,) <$> load outputR 0 <*> load outputG 0 <*> load outputB 0
@@ -534,22 +551,23 @@ compileRenderer' prepOutputEnv name code = runExcept $
 compileCode :: forall m env
              . (MonadModuleBuilder m, MonadIRBuilder m, MonadError String m, MonadFix m)
             => (String -> Operand)
+            -> ArenaState
             -> Code env
             -> ReaderT (Context OperandPtr env) m ()
-compileCode getExtern = indexedFold @(OperandPtrContext m) $ \case
+compileCode getExtern arena = indexedFold @(OperandPtrContext m) $ \case
 
   Block body -> sequence_ body
 
   NoOp -> pure ()
 
   Set pf _ e -> do
-    x <- value_ getExtern e
+    x <- value_ getExtern arena e
     ctx <- ask
     storeOperand x (withKnownType (typeOfValue e) (getBinding ctx pf))
     pure ()
 
   Let pf name val body -> do
-    x <- value_ getExtern val
+    x <- value_ getExtern arena val
     let t = typeOfValue val
     ptr <- allocaOp t
     storeOperand x ptr
@@ -558,7 +576,7 @@ compileCode getExtern = indexedFold @(OperandPtrContext m) $ \case
       lift (runReaderT body ctx)
 
   IfThenElse cond yes no -> mdo
-    c <- value_ getExtern cond >>= detypeOperand BooleanType
+    c <- value_ getExtern arena cond >>= detypeOperand BooleanType
     condBr c yesLabel noLabel
 
     yesLabel <- block
@@ -577,11 +595,87 @@ compileCode getExtern = indexedFold @(OperandPtrContext m) $ \case
 
     loop <- block
     void body
-    test <- value_ getExtern cond >>= detypeOperand BooleanType
+    test <- value_ getExtern arena cond >>= detypeOperand BooleanType
     condBr test loop exit
 
     exit <- block
     pure ()
+
+  -- | Iterate over each element of a list variable.
+  ForEach pfList _listName (ListType itemTy) itemName pfNoItem _env _ body ->
+    recallIsAbsent pfNoItem $ do
+    ctx <- ask
+    -- Load the head pointer from the list variable's stack slot.
+    headPtr <- lift $ getListOp <$> derefOperand (getBinding ctx pfList)
+    -- Allocate a stack slot to track the current node pointer.
+    currPtrAlloca <- lift $ alloca (AST.ptr AST.i8) Nothing 0
+    lift $ store currPtrAlloca 0 headPtr
+    -- Allocate a stack slot for the current element.
+    elemSlot <- lift $ allocaOp itemTy
+    mdo
+      lift $ br loopHead
+
+      loopHead <- block `named` "foreach_head"
+      currPtr <- lift $ load currPtrAlloca 0
+      isNull  <- lift $ icmp P.EQ currPtr nullI8Ptr
+      lift $ condBr isNull loopExit loopBody
+
+      loopBody <- block `named` "foreach_body"
+      elem_ <- lift $ loadListElem itemTy currPtr
+      lift $ storeOperand elem_ elemSlot
+      -- Run the body with the element bound in the context.
+      lift $ runReaderT body (Bind itemName itemTy elemSlot ctx)
+      nextPtr <- lift $ loadListNext currPtr
+      lift $ store currPtrAlloca 0 nextPtr
+      lift $ br loopHead
+
+      loopExit <- block `named` "foreach_exit"
+      pure ()
+
+  -- | Find the first list element matching a predicate; run action or fallback.
+  Lookup pfList _listName (ListType itemTy) itemName pfNoItem _extEnv _env
+         predicate action fallback ->
+    recallIsAbsent pfNoItem $ do
+    ctx <- ask
+    -- Load the head pointer from the list variable's stack slot.
+    headPtr <- lift $ getListOp <$> derefOperand (getBinding ctx pfList)
+    currPtrAlloca <- lift $ alloca (AST.ptr AST.i8) Nothing 0
+    lift $ store currPtrAlloca 0 headPtr
+    elemSlot <- lift $ allocaOp itemTy
+    mdo
+      lift $ br loopHead
+
+      loopHead <- block `named` "lookup_head"
+      currPtr <- lift $ load currPtrAlloca 0
+      isNull  <- lift $ icmp P.EQ currPtr nullI8Ptr
+      lift $ condBr isNull notFound loopBody
+
+      loopBody <- block `named` "lookup_body"
+      elem_ <- lift $ loadListElem itemTy currPtr
+      lift $ storeOperand elem_ elemSlot
+      -- Evaluate the predicate in the extended context.
+      let extCtx = Bind itemName itemTy elemSlot ctx
+      testBit <- lift $ runReaderT (value_ getExtern arena predicate) extCtx
+                   >>= detypeOperand BooleanType
+      lift $ condBr testBit foundBlock nextIter
+
+      nextIter <- block `named` "lookup_next"
+      nextPtr <- lift $ loadListNext currPtr
+      lift $ store currPtrAlloca 0 nextPtr
+      lift $ br loopHead
+
+      foundBlock <- block `named` "lookup_found"
+      lift $ runReaderT action extCtx
+      lift $ br exit
+
+      notFound <- block `named` "lookup_not_found"
+      lift $ case fallback of
+        Nothing  -> pure ()
+        Just alt -> runReaderT alt ctx
+      lift $ br exit
+
+      exit <- block `named` "lookup_exit"
+      pure ()
 
   _ -> error "unsupported command"
 

--- a/fractalstream-backend-llvm/src/Backend/LLVM/Code.hs
+++ b/fractalstream-backend-llvm/src/Backend/LLVM/Code.hs
@@ -4,6 +4,8 @@ module Backend.LLVM.Code
   ( --compile
 --  , compileRenderer
    compileRenderer'
+  , compileToolHandler
+  , DrawVTable(..)
   ) where
 
 import FractalStream.Prelude
@@ -28,6 +30,7 @@ import Unsafe.Coerce (unsafeCoerce)
 
 import Language.Type
 import Language.Code
+import Language.Draw
 import Data.Indexed.Functor
 
 toParameterList :: EnvironmentProxy env -> [(AST.Type, ParameterName)]
@@ -468,7 +471,7 @@ compileRenderer' prepOutputEnv name code = runExcept $
           pixelIndex <- load pixelIndexPtr 0
           overwritePrepOutputs prepOutputEnv prepArrayPtrs pixelIndex argMap
 
-          runReaderT (compileCode getExtern arenaState code) args
+          runReaderT (compileCode getExtern arenaState Nothing code) args
           overflowed <- load overflowFlag 0
           (cr0, cg0, cb0) <- case getBinding args pfOutput of
             PtrOp (ColorOp outputR outputG outputB) ->
@@ -559,13 +562,91 @@ compileRenderer' prepOutputEnv name code = runExcept $
         retVoid
 
 
+-- | C function pointers (one per draw primitive) that a compiled tool's
+-- 'DrawCommand's call back into Haskell.  Each field is an LLVM operand of the
+-- appropriate function-pointer type.  Viewers don't draw, so they pass
+-- 'Nothing' to 'compileCode'; tool handlers pass 'Just'.
+data DrawVTable = DrawVTable
+  { dvClear  :: Operand   -- ^ void()
+  , dvStroke :: Operand   -- ^ void(i8 r, i8 g, i8 b)
+  , dvFill   :: Operand   -- ^ void(i8 r, i8 g, i8 b)
+  , dvPoint  :: Operand   -- ^ void(double x, double y)
+  , dvLine   :: Operand   -- ^ void(double x1, double y1, double x2, double y2)
+  , dvCircle :: Operand   -- ^ void(i8 fill, double r, double x, double y)
+  , dvRect   :: Operand   -- ^ void(i8 fill, double x1, double y1, double x2, double y2)
+  }
+
+-- | Compile a single tool event handler into a native function.  Unlike a
+-- viewer kernel there is no pixel loop: the body runs once.  ABI (in order):
+-- seven draw-callback function pointers (passed as i8*), the arena pointer and
+-- size, a 1-byte overflow-out pointer, then the handler's environment values
+-- (read-only inputs, marshalled like viewer args).  Draw commands in the body
+-- 'call' the vtable; list allocations use the arena; on overflow the kernel
+-- writes 1 to the overflow byte.
+compileToolHandler :: forall e
+                    . EnvironmentProxy e
+                   -> AST.Name
+                   -> Code e
+                   -> Either String AST.Module
+compileToolHandler envp name code = runExcept $
+  buildModuleT "compiled tool handler" $ do
+    let drawParams =
+          [ (AST.ptr AST.i8, ParameterName "draw.clear")
+          , (AST.ptr AST.i8, ParameterName "draw.stroke")
+          , (AST.ptr AST.i8, ParameterName "draw.fill")
+          , (AST.ptr AST.i8, ParameterName "draw.point")
+          , (AST.ptr AST.i8, ParameterName "draw.line")
+          , (AST.ptr AST.i8, ParameterName "draw.circle")
+          , (AST.ptr AST.i8, ParameterName "draw.rect") ]
+        arenaParams    = [ (AST.ptr AST.i8, ParameterName "#arenaPtr")
+                         , (AST.i32,        ParameterName "#arenaSize") ]
+        overflowParams = [ (AST.ptr AST.i8, ParameterName "#overflowOut") ]
+        params = drawParams ++ arenaParams ++ overflowParams ++ toParameterList envp
+        fnPtrTy rTy aTys = AST.ptr (AST.FunctionType rTy aTys False)
+    function name params AST.void $ \allArgs -> do
+      getExtern <- getGetExtern
+      _entry <- block `named` "tool_entry"
+      let (drawArgs, afterDraw) = splitAt 7 allArgs
+          (arenaPtrArg : arenaSizeArg : overflowArg : rawEnvArgs) = afterDraw
+          [clearP, strokeP, fillP, pointP, lineP, circleP, rectP] = drawArgs
+
+      bumpAlloca <- alloca (AST.ptr AST.i8) Nothing 0
+      store bumpAlloca 0 arenaPtrArg
+      arenaEnd <- gep arenaPtrArg [arenaSizeArg]
+      overflowFlag <- alloca AST.i1 Nothing 0
+      store overflowFlag 0 (C.bit 0)
+      let arenaState = ArenaState bumpAlloca arenaEnd overflowFlag
+
+      clearF  <- bitcast clearP  (fnPtrTy AST.void [])
+      strokeF <- bitcast strokeP (fnPtrTy AST.void [AST.i8, AST.i8, AST.i8])
+      fillF   <- bitcast fillP   (fnPtrTy AST.void [AST.i8, AST.i8, AST.i8])
+      pointF  <- bitcast pointP  (fnPtrTy AST.void [AST.double, AST.double])
+      lineF   <- bitcast lineP
+                   (fnPtrTy AST.void [AST.double, AST.double, AST.double, AST.double])
+      circleF <- bitcast circleP
+                   (fnPtrTy AST.void [AST.i8, AST.double, AST.double, AST.double])
+      rectF   <- bitcast rectP
+                   (fnPtrTy AST.void [AST.i8, AST.double, AST.double, AST.double, AST.double])
+      let vt = DrawVTable { dvClear = clearF, dvStroke = strokeF, dvFill = fillF
+                          , dvPoint = pointF, dvLine = lineF, dvCircle = circleF
+                          , dvRect = rectF }
+
+      args <- allocaToolArgs envp rawEnvArgs
+      runReaderT (compileCode getExtern arenaState (Just vt) code) args
+
+      ovf  <- load overflowFlag 0
+      ovf8 <- zext ovf AST.i8
+      store overflowArg 0 ovf8
+      retVoid
+
 compileCode :: forall m env
              . (MonadModuleBuilder m, MonadIRBuilder m, MonadError String m, MonadFix m)
             => (String -> Operand)
             -> ArenaState
+            -> Maybe DrawVTable
             -> Code env
             -> ReaderT (Context OperandPtr env) m ()
-compileCode getExtern arena = indexedFold @(OperandPtrContext m) $ \case
+compileCode getExtern arena mvtable = indexedFold @(OperandPtrContext m) $ \case
 
   Block body -> sequence_ body
 
@@ -688,7 +769,31 @@ compileCode getExtern arena = indexedFold @(OperandPtrContext m) $ \case
       exit <- block `named` "lookup_exit"
       pure ()
 
-  _ -> error "unsupported command"
+  DrawCommand d -> case mvtable of
+    Nothing -> throwError "internal error: draw command compiled without a draw vtable"
+    Just vt -> do
+      -- A point Value has type (Pair RealT RealT) -> PairOp (RealOp x) (RealOp y).
+      let withPt pv k = value_ getExtern arena pv >>= \case
+            PairOp (RealOp x) (RealOp y) -> k x y
+      case d of
+        Clear _ -> void $ call (dvClear vt) []
+        SetStroke _ cv -> value_ getExtern arena cv >>= \case
+          ColorOp r g b -> void $ call (dvStroke vt) [(r,[]),(g,[]),(b,[])]
+        SetFill _ cv -> value_ getExtern arena cv >>= \case
+          ColorOp r g b -> void $ call (dvFill vt) [(r,[]),(g,[]),(b,[])]
+        DrawPoint _ pv -> withPt pv $ \x y ->
+          void $ call (dvPoint vt) [(x,[]),(y,[])]
+        DrawLine _ p1 p2 -> withPt p1 $ \x1 y1 -> withPt p2 $ \x2 y2 ->
+          void $ call (dvLine vt) [(x1,[]),(y1,[]),(x2,[]),(y2,[])]
+        DrawCircle _ fill rv pv -> value_ getExtern arena rv >>= \case
+          RealOp r -> withPt pv $ \x y ->
+            void $ call (dvCircle vt)
+              [(C.int8 (if fill then 1 else 0),[]),(r,[]),(x,[]),(y,[])]
+        DrawRect _ fill p1 p2 -> withPt p1 $ \x1 y1 -> withPt p2 $ \x2 y2 ->
+          void $ call (dvRect vt)
+            [(C.int8 (if fill then 1 else 0),[]),(x1,[]),(y1,[]),(x2,[]),(y2,[])]
+        Write _ _ _ ->
+          throwError "The LLVM backend cannot compile `write` (text) yet"
 
 
 data OperandPtrContext :: (* -> *) -> Environment -> Exp *
@@ -715,3 +820,25 @@ allocaArg t op = do
   x <- typedOperand t op
   storeOperand x ptr
   pure ptr
+
+-- | Bind a tool handler's environment arguments.  Complex and Color values are
+-- already passed as pointers, so we bind them in/out (pointing directly at the
+-- caller's buffer) so that a 'Set' of a config variable is visible to the host
+-- after the call (used for write-back, e.g. the Select tool).  Everything else
+-- is bound by value as usual (no write-back yet).
+allocaToolArgs :: (MonadModuleBuilder m, MonadIRBuilder m, MonadError String m)
+               => EnvironmentProxy env
+               -> [Operand]
+               -> m (Context OperandPtr env)
+allocaToolArgs EmptyEnvProxy [] = pure EmptyContext
+allocaToolArgs (BindingProxy name ty env) (op:ops) =
+  Bind name ty <$> bindToolArg ty op <*> allocaToolArgs env ops
+allocaToolArgs _ _ =
+  throwError "internal error: mismatched environment/args counts (tool)"
+
+bindToolArg :: (MonadModuleBuilder m, MonadIRBuilder m, MonadError String m)
+            => TypeProxy t -> Operand -> m (PtrOp t)
+bindToolArg ty op = case ty of
+  ComplexType -> typedOperandPtr ComplexType op
+  ColorType   -> typedOperandPtr ColorType op
+  _           -> allocaArg ty op

--- a/fractalstream-backend-llvm/src/Backend/LLVM/Code.hs
+++ b/fractalstream-backend-llvm/src/Backend/LLVM/Code.hs
@@ -400,12 +400,17 @@ compileRenderer' prepOutputEnv name code = runExcept $
         blockWidthPtr  <- allocaArg IntegerType blockWidthArg
         blockHeightPtr <- allocaArg IntegerType blockHeightArg
         subsamplesPtr  <- allocaArg IntegerType subsamplesArg
+
         -- Arena setup: bumpAlloca tracks the current allocation position.
         -- arenaEnd is constant = arenaBase + arenaSize.
+        -- overflowFlag is reset per subsample and set by arenaAlloc on overflow.
         bumpAlloca <- alloca (AST.ptr AST.i8) Nothing 0
         store bumpAlloca 0 arenaPtrArg
         arenaEnd <- gep arenaPtrArg [arenaSizeArg]
-        let arenaState = ArenaState bumpAlloca arenaEnd
+        overflowFlag <- alloca AST.i1 Nothing 0
+        store overflowFlag 0 (C.bit 0)
+        let arenaState = ArenaState bumpAlloca arenaEnd overflowFlag
+
         args <- allocaArgs (envProxy (Proxy @(ViewerEnv env))) rawArgs
         x0 <- derefOperand (getBinding args pfX)  >>= \case RealOp v -> pure v
         y0 <- derefOperand (getBinding args pfY)  >>= \case RealOp v -> pure v
@@ -457,19 +462,25 @@ compileRenderer' prepOutputEnv name code = runExcept $
           -- Reset the arena at the start of each subsample so each pixel's
           -- dynamic list allocations are independent.
           store bumpAlloca 0 arenaPtrArg
+          store overflowFlag 0 (C.bit 0)
 
           -- Load prep output vars from their flat arrays before the kernel.
           pixelIndex <- load pixelIndexPtr 0
           overwritePrepOutputs prepOutputEnv prepArrayPtrs pixelIndex argMap
 
           runReaderT (compileCode getExtern arenaState code) args
+          overflowed <- load overflowFlag 0
           (cr0, cg0, cb0) <- case getBinding args pfOutput of
             PtrOp (ColorOp outputR outputG outputB) ->
               (,,) <$> load outputR 0 <*> load outputG 0 <*> load outputB 0
+          -- On arena overflow, render the pixel magenta so it's visually obvious.
+          cr0' <- select overflowed (C.int8 255) cr0
+          cg0' <- select overflowed (C.int8 0)   cg0
+          cb0' <- select overflowed (C.int8 255) cb0
 
-          cr <- zext cr0 AST.i32
-          cg <- zext cg0 AST.i32
-          cb <- zext cb0 AST.i32
+          cr <- zext cr0' AST.i32
+          cg <- zext cg0' AST.i32
+          cb <- zext cb0' AST.i32
           do
             tmp1 <- load accR 0
             tmp2 <- add tmp1 cr

--- a/fractalstream-backend-llvm/src/Backend/LLVM/Operand.hs
+++ b/fractalstream-backend-llvm/src/Backend/LLVM/Operand.hs
@@ -366,13 +366,17 @@ storeListElem t nodePtr op = do
 -- | Arena state threaded through LLVM IR generation for dynamic list allocation.
 -- The arena is a flat byte buffer; a bump pointer is advanced on each allocation
 -- and reset to the base at the start of each pixel/subsample computation.
+-- asOverflowFlag is an i1* stack slot set to 1 on the first failed allocation;
+-- checked after compileCode to render the pixel magenta.
 data ArenaState = ArenaState
-  { asBumpAlloca :: Operand  -- ^ i8** stack slot holding the current bump pointer
-  , asArenaEnd   :: Operand  -- ^ i8* constant end of the arena (base + capacity)
+  { asBumpAlloca   :: Operand  -- ^ i8** stack slot holding the current bump pointer
+  , asArenaEnd     :: Operand  -- ^ i8* constant end of the arena (base + capacity)
+  , asOverflowFlag :: Operand  -- ^ i1* stack slot; set to 1 on overflow
   }
 
 -- | Emit inline bump-allocation of 'size' bytes (must be a multiple of 8).
--- Returns the allocated i8* on success; returns null on overflow.
+-- Returns the allocated i8* on success; returns null on overflow and sets the
+-- overflow flag in ArenaState.
 arenaAlloc :: (MonadModuleBuilder m, MonadIRBuilder m, MonadFix m)
            => ArenaState
            -> Int        -- ^ compile-time byte count (multiple of 8)
@@ -388,6 +392,7 @@ arenaAlloc ArenaState{..} size = mdo
   br mergeBb
 
   overflowBb <- block
+  store asOverflowFlag 0 (bit 1)  -- signal overflow
   br mergeBb
 
   mergeBb <- block

--- a/fractalstream-backend-llvm/src/Backend/LLVM/Operand.hs
+++ b/fractalstream-backend-llvm/src/Backend/LLVM/Operand.hs
@@ -376,7 +376,8 @@ data ArenaState = ArenaState
 
 -- | Emit inline bump-allocation of 'size' bytes (must be a multiple of 8).
 -- Returns the allocated i8* on success; returns null on overflow and sets the
--- overflow flag in ArenaState.
+-- overflow flag in ArenaState. Callers MUST null-check the result and bail out
+-- of list construction on overflow (see the builders in Backend.LLVM.Value).
 arenaAlloc :: (MonadModuleBuilder m, MonadIRBuilder m, MonadFix m)
            => ArenaState
            -> Int        -- ^ compile-time byte count (multiple of 8)

--- a/fractalstream-backend-llvm/src/Backend/LLVM/Operand.hs
+++ b/fractalstream-backend-llvm/src/Backend/LLVM/Operand.hs
@@ -1,3 +1,4 @@
+{-# language RecursiveDo #-}
 module Backend.LLVM.Operand
   ( toLLVMType
   , toLLVMPtrType
@@ -7,12 +8,21 @@ module Backend.LLVM.Operand
   , PtrOp_
   , PtrOp(..)
   , getBooleanOp
+  , getListOp
+  , getIntegerOp
   , typedOperand
   , typedOperandPtr
   , detypeOperand
   , derefOperand
   , storeOperand
   , allocaOp
+  , nullI8Ptr
+  , listNodeStride
+  , loadListNext
+  , loadListElem
+  , storeListElem
+  , ArenaState(..)
+  , arenaAlloc
   -- * Re-exports
   , Operand
   ) where
@@ -32,6 +42,8 @@ import LLVM.IRBuilder.Monad
 import LLVM.IRBuilder.Instruction
 import LLVM.IRBuilder.Constant
 import LLVM.AST.Operand hiding (local)
+import qualified LLVM.AST.IntegerPredicate as P
+import Control.Monad.Fix
 
 data OperandPtr :: Symbol -> FSType -> Exp *
 type instance Eval (OperandPtr name t) = PtrOp t
@@ -50,7 +62,11 @@ data Op (t :: FSType) where
   ComplexOp :: Operand -> Operand -> Op 'ComplexT
   ColorOp   :: Operand -> Operand -> Operand -> Op 'ColorT
   PairOp    :: forall t1 t2. Op t1 -> Op t2 -> Op ('Pair t1 t2)
-  ListOp    :: forall t. Op ('ListT t)
+  -- | A list is represented as a pointer to the head node (null = empty).
+  -- Node layout (contiguous in memory):
+  --   bytes 0-7:  next pointer (i8*, null = end of list)
+  --   bytes 8+:   element data (type-dependent, see listNodeStride)
+  ListOp    :: forall t. Operand -> Op ('ListT t)
   TextOp    :: Op 'TextT
 
 deriving instance (Show (Op t))
@@ -60,6 +76,12 @@ newtype PtrOp t = PtrOp (Op t)
 
 getBooleanOp :: Op 'BooleanT -> Operand
 getBooleanOp (BooleanOp x) = x
+
+getListOp :: Op ('ListT t) -> Operand
+getListOp (ListOp headPtr) = headPtr
+
+getIntegerOp :: Op 'IntegerT -> Operand
+getIntegerOp (IntegerOp x) = x
 
 storeOperand :: (MonadModuleBuilder m, MonadIRBuilder m, MonadError String m)
              => Op t -> PtrOp t -> m ()
@@ -75,7 +97,7 @@ storeOperand op (PtrOp ptrOp) = case (op, ptrOp) of
     store ptrR 0 r
     store ptrG 0 g
     store ptrB 0 b
-  (ListOp, ListOp) -> pure ()
+  (ListOp headPtr, ListOp ptrSlot) -> store ptrSlot 0 headPtr
   (TextOp, TextOp) -> pure ()
   _ -> throwError "TODO: Unhandled store type"
 
@@ -100,7 +122,7 @@ detypeOperand _t = \case
     c2 <- insertValue c1 g [1]
     insertValue c2 b [2]
   PairOp _op1 _op2 -> throwError "TODO: detypeOperand PairOp"
-  ListOp -> throwError "TODO: detypeOperand ListOp"
+  ListOp headPtr -> pure headPtr
   TextOp -> throwError "TODO: detypeOperand TextOp"
 
 derefOperand :: (MonadModuleBuilder m, MonadIRBuilder m, MonadError String m)
@@ -119,7 +141,7 @@ derefOperand (PtrOp ptrOp) = case ptrOp of
             <*> load ptrB 0
   PairOp t1 t2 ->
     PairOp <$> derefOperand (PtrOp t1) <*> derefOperand (PtrOp t2)
-  ListOp -> throwError "TODO: derefOperand ListOp"
+  ListOp ptrSlot -> ListOp <$> load ptrSlot 0
   TextOp -> throwError "TODO: derefOperand TextOp"
 
 -- | Get the LLVM function argument type corresponding to
@@ -136,7 +158,8 @@ toLLVMType = \case
                                                       , toLLVMType t2 ])
   ColorType      -> AST.ptr (AST.ArrayType 3 AST.i8)
   ImageType      -> AST.i32
-  ListType {}    -> AST.i32
+  -- A list is passed as an i8* pointing to the head node (null = empty list).
+  ListType {}    -> AST.ptr AST.i8
   TextType       -> AST.i32 -- fixme
 
 toLLVMPtrType :: forall t. TypeProxy t -> AST.Type
@@ -151,7 +174,8 @@ toLLVMPtrType = \case
                                                       , toLLVMType t2 ])
   ColorType      -> AST.ptr (AST.ArrayType 3 AST.i8)
   ImageType      -> AST.ptr AST.i32
-  ListType {}    -> AST.ptr AST.i32
+  -- A list slot holds a single i8* (the head pointer).
+  ListType {}    -> AST.ptr (AST.ptr AST.i8)
   TextType       -> AST.ptr AST.i32
 
 allocaOp :: (MonadModuleBuilder m, MonadIRBuilder m, MonadError String m)
@@ -172,7 +196,11 @@ allocaOp = \case
     PtrOp ptr2 <- allocaOp t2
     pure (PtrOp (PairOp ptr1 ptr2))
 
-  ListType _ -> pure (PtrOp ListOp)
+  ListType _ -> do
+    -- Allocate a stack slot that holds an i8* (the head pointer).
+    ptrSlot <- alloca (AST.ptr AST.i8) Nothing 0
+    store ptrSlot 0 nullI8Ptr
+    pure (PtrOp (ListOp ptrSlot))
 
   TextType -> pure (PtrOp TextOp)
 
@@ -230,6 +258,137 @@ typedOperand t op = do
              PairOp <$> typedOperand t1 x1
                     <*> typedOperand t2 x2
 
-           ListType _ -> pure ListOp
+           -- The argument IS the head pointer; wrap it directly.
+           ListType _ -> pure (ListOp op)
            TextType -> pure TextOp
            _ -> throwError ("TODO: missing case in typedOperand for type " ++ showType t)
+
+-- | A null i8* constant (used as the empty-list sentinel).
+nullI8Ptr :: Operand
+nullI8Ptr = ConstantOperand (AST.Null (AST.ptr AST.i8))
+
+-- | Byte stride between consecutive nodes in a serialized list buffer.
+-- Layout: 8 bytes (next i8* pointer) + element data, rounded up to 8-byte alignment.
+listNodeStride :: TypeProxy t -> Int
+listNodeStride t = roundUp8 (8 + elemBytes t)
+  where
+    roundUp8 n  = ((n + 7) `div` 8) * 8
+    elemBytes BooleanType  = 1
+    elemBytes IntegerType  = 4
+    elemBytes RealType     = 8
+    elemBytes ComplexType  = 16  -- two doubles
+    elemBytes ColorType    = 3
+    elemBytes (ListType _) = 8   -- nested list: a head pointer
+    elemBytes _            = 8   -- fallback for unsupported types
+
+-- | Emit LLVM IR to load the 'next' pointer from a list node.
+-- The node pointer is an i8*; the next field lives at byte offset 0.
+loadListNext :: (MonadModuleBuilder m, MonadIRBuilder m, MonadError String m)
+             => Operand   -- ^ i8* pointing to the current node
+             -> m Operand -- ^ i8* pointing to the next node (or null)
+loadListNext nodePtr = do
+  -- Cast the node ptr to i8** so we can load a pointer from it.
+  nextPtrPtr <- bitcast nodePtr (AST.ptr (AST.ptr AST.i8))
+  load nextPtrPtr 0
+
+-- | Emit LLVM IR to load the element value from a list node.
+-- The element lives at byte offset 8 (just after the 8-byte next pointer).
+loadListElem :: (MonadModuleBuilder m, MonadIRBuilder m, MonadError String m)
+             => TypeProxy t
+             -> Operand     -- ^ i8* pointing to the current node
+             -> m (Op t)
+loadListElem t nodePtr = do
+  elemI8 <- gep nodePtr [int32 8]
+  case t of
+    BooleanType -> do
+      p <- bitcast elemI8 (AST.ptr AST.i1)
+      BooleanOp <$> load p 0
+    IntegerType -> do
+      p <- bitcast elemI8 (AST.ptr AST.i32)
+      IntegerOp <$> load p 0
+    RealType -> do
+      p <- bitcast elemI8 (AST.ptr AST.double)
+      RealOp <$> load p 0
+    ComplexType -> do
+      p <- bitcast elemI8 (AST.ptr (AST.ArrayType 2 AST.double))
+      xPtr <- gep p [int32 0, int32 0]
+      yPtr <- gep p [int32 0, int32 1]
+      ComplexOp <$> load xPtr 0 <*> load yPtr 0
+    ColorType -> do
+      p <- bitcast elemI8 (AST.ptr (AST.ArrayType 3 AST.i8))
+      rPtr <- gep p [int32 0, int32 0]
+      gPtr <- gep p [int32 0, int32 1]
+      bPtr <- gep p [int32 0, int32 2]
+      ColorOp <$> load rPtr 0 <*> load gPtr 0 <*> load bPtr 0
+    ListType _ -> do
+      p <- bitcast elemI8 (AST.ptr (AST.ptr AST.i8))
+      ListOp <$> load p 0
+    _ -> throwError ("loadListElem: unsupported element type " ++ showType t)
+
+-- | Write element data into a list node at the given byte offset (offset 8 past
+-- the start of the node).  Mirror image of 'loadListElem'.
+storeListElem :: (MonadModuleBuilder m, MonadIRBuilder m, MonadError String m)
+              => TypeProxy t
+              -> Operand   -- ^ i8* base of the node
+              -> Op t
+              -> m ()
+storeListElem t nodePtr op = do
+  elemI8 <- gep nodePtr [int32 8]
+  case (t, op) of
+    (BooleanType, BooleanOp v) -> do
+      p <- bitcast elemI8 (AST.ptr AST.i1)
+      store p 0 v
+    (IntegerType, IntegerOp v) -> do
+      p <- bitcast elemI8 (AST.ptr AST.i32)
+      store p 0 v
+    (RealType, RealOp v) -> do
+      p <- bitcast elemI8 (AST.ptr AST.double)
+      store p 0 v
+    (ComplexType, ComplexOp x y) -> do
+      p <- bitcast elemI8 (AST.ptr (AST.ArrayType 2 AST.double))
+      xPtr <- gep p [int32 0, int32 0]
+      yPtr <- gep p [int32 0, int32 1]
+      store xPtr 0 x
+      store yPtr 0 y
+    (ColorType, ColorOp r g b) -> do
+      p <- bitcast elemI8 (AST.ptr (AST.ArrayType 3 AST.i8))
+      rPtr <- gep p [int32 0, int32 0]
+      gPtr <- gep p [int32 0, int32 1]
+      bPtr <- gep p [int32 0, int32 2]
+      store rPtr 0 r
+      store gPtr 0 g
+      store bPtr 0 b
+    (ListType _, ListOp headPtr) -> do
+      p <- bitcast elemI8 (AST.ptr (AST.ptr AST.i8))
+      store p 0 headPtr
+    _ -> throwError ("storeListElem: unsupported type " ++ showType t)
+
+-- | Arena state threaded through LLVM IR generation for dynamic list allocation.
+-- The arena is a flat byte buffer; a bump pointer is advanced on each allocation
+-- and reset to the base at the start of each pixel/subsample computation.
+data ArenaState = ArenaState
+  { asBumpAlloca :: Operand  -- ^ i8** stack slot holding the current bump pointer
+  , asArenaEnd   :: Operand  -- ^ i8* constant end of the arena (base + capacity)
+  }
+
+-- | Emit inline bump-allocation of 'size' bytes (must be a multiple of 8).
+-- Returns the allocated i8* on success; returns null on overflow.
+arenaAlloc :: (MonadModuleBuilder m, MonadIRBuilder m, MonadFix m)
+           => ArenaState
+           -> Int        -- ^ compile-time byte count (multiple of 8)
+           -> m Operand
+arenaAlloc ArenaState{..} size = mdo
+  bump    <- load asBumpAlloca 0
+  newBump <- gep bump [int32 (fromIntegral size)]
+  overflow <- icmp P.UGT newBump asArenaEnd
+  condBr overflow overflowBb okBb
+
+  okBb <- block
+  store asBumpAlloca 0 newBump
+  br mergeBb
+
+  overflowBb <- block
+  br mergeBb
+
+  mergeBb <- block
+  phi [(bump, okBb), (nullI8Ptr, overflowBb)]

--- a/fractalstream-backend-llvm/src/Backend/LLVM/Value.hs
+++ b/fractalstream-backend-llvm/src/Backend/LLVM/Value.hs
@@ -1,4 +1,4 @@
-{-# language OverloadedStrings #-}
+{-# language OverloadedStrings, RecursiveDo #-}
 module Backend.LLVM.Value
   ( value_
   , buildValue
@@ -22,11 +22,13 @@ import qualified LLVM.AST.FloatingPointPredicate as P
 import qualified LLVM.IRBuilder.Instruction as I
 import qualified LLVM.AST.Type as AST
 
+import Control.Monad.Fix
 import qualified Data.Map as Map
 
 value_ :: forall env t m
-       . (MonadModuleBuilder m, MonadIRBuilder m, MonadError String m)
+       . (MonadModuleBuilder m, MonadIRBuilder m, MonadError String m, MonadFix m)
       => (String -> Operand)
+      -> ArenaState
       -> Value '(env, t)
       -> ReaderT (Context OperandPtr env) m (Op t)
 value_ = buildValue
@@ -36,11 +38,12 @@ type instance Eval (CtxOp m et) =
   ReaderT (Context OperandPtr (Env et)) m (Op (Ty et))
 
 buildValue :: forall env t' m
-            . (MonadModuleBuilder m, MonadIRBuilder m, MonadError String m)
+            . (MonadModuleBuilder m, MonadIRBuilder m, MonadError String m, MonadFix m)
            => (String -> Operand)
+           -> ArenaState
            -> Value '(env, t')
            -> ReaderT (Context OperandPtr env) m (Op t')
-buildValue getExtern = indexedFold go'
+buildValue getExtern arena = indexedFold go'
   where
     go' :: forall et. ValueF (CtxOp m) et -> Eval (CtxOp m et)
     go' x = case toIndex x of { EnvType _ -> go x }
@@ -74,14 +77,89 @@ buildValue getExtern = indexedFold go'
       Const (Scalar t _) ->
         throwError ("The LLVM backend can not compile constants of type " ++ showType t)
 
-      List {} -> throwError "The LLVM backend can not compile list values"
-      Join {} -> throwError "The LLVM backend can not compile list values"
-      Remove {} -> throwError "The LLVM backend can not compile list values"
-      Find {} -> throwError "The LLVM backend can not compile list values"
-      Transform {} -> throwError "The LLVM backend can not compile list values"
-      Range {} -> throwError "The LLVM backend can not compile list values"
-      Length {} -> throwError "The LLVM backend can not compile list values"
-      Index {} -> throwError "The LLVM backend can not compile list values"
+      -- ------------------------------------------------------------------ --
+      -- List literal: allocate one node per element in the arena, link them.
+      -- ------------------------------------------------------------------ --
+      List ty mElems -> do
+        let stride = listNodeStride ty
+        elems <- sequence mElems   -- evaluate all elements first
+        case elems of
+          [] -> pure (ListOp nullI8Ptr)
+          _  -> lift $ buildLitList arena ty stride elems
+
+      -- ------------------------------------------------------------------ --
+      -- Join: copy every list from every input (conservative; safe for
+      -- future mutations).  Concatenate the copies in order.
+      -- ------------------------------------------------------------------ --
+      Join ty mLists -> do
+        lists <- sequence mLists
+        let headPtrs = map getListOp lists
+        lift $ buildJoin arena ty headPtrs
+
+      -- ------------------------------------------------------------------ --
+      -- Remove: filter by predicate; keep elements where pred is FALSE.
+      -- ------------------------------------------------------------------ --
+      Remove name ty pf mxs mtest -> recallIsAbsent pf $ do
+        ctx <- ask
+        xs <- mxs
+        let headPtr = getListOp xs
+        elemSlot <- allocaOp ty
+        lift $ buildFilter arena ty headPtr elemSlot $ \slot -> do
+          testOp <- runReaderT mtest (Bind name ty slot ctx)
+          detypeOperand BooleanType testOp
+
+      -- ------------------------------------------------------------------ --
+      -- Transform: apply a function to every element, producing a new list.
+      -- ------------------------------------------------------------------ --
+      Transform name ty1 _ty2 pf mxs mf -> recallIsAbsent pf $ do
+        ctx <- ask
+        xs <- mxs
+        let headPtr = getListOp xs
+            ty2 = _ty2
+        elemSlot <- allocaOp ty1
+        lift $ buildMap arena ty1 ty2 headPtr elemSlot $ \slot ->
+          runReaderT mf (Bind name ty1 slot ctx)
+
+      -- ------------------------------------------------------------------ --
+      -- Find: return the first element matching pred, or the default.
+      -- ------------------------------------------------------------------ --
+      Find name ty pf mxs mtest mdefault -> recallIsAbsent pf $ do
+        ctx <- ask
+        xs    <- mxs
+        defOp <- mdefault
+        let headPtr = getListOp xs
+        elemSlot <- allocaOp ty
+        lift $ buildFind arena ty headPtr elemSlot defOp $ \slot -> do
+          testOp <- runReaderT mtest (Bind name ty slot ctx)
+          detypeOperand BooleanType testOp
+
+      -- ------------------------------------------------------------------ --
+      -- Length: count nodes.
+      -- ------------------------------------------------------------------ --
+      Length ty mxs -> do
+        xs <- mxs
+        let headPtr = getListOp xs
+        lift $ buildLength headPtr (toLLVMType ty)
+
+      -- ------------------------------------------------------------------ --
+      -- Index: 1-based indexing, optionally cyclic.
+      -- ------------------------------------------------------------------ --
+      Index ty cyclic mxs mi -> do
+        xs <- mxs
+        i  <- mi
+        let headPtr = getListOp xs
+            iOp = case i of IntegerOp v -> v
+        lift $ buildIndex arena ty cyclic headPtr iOp
+
+      -- ------------------------------------------------------------------ --
+      -- Range: integer range [lo..hi].
+      -- ------------------------------------------------------------------ --
+      Range mlo mhi -> do
+        lo <- mlo
+        hi <- mhi
+        let loOp = case lo of IntegerOp v -> v
+            hiOp = case hi of IntegerOp v -> v
+        lift $ buildRange arena loOp hiOp
 
       ConcatText {} -> throwError "The LLVM backend can not compile text values"
 
@@ -454,6 +532,316 @@ buildValue getExtern = indexedFold go'
           ComplexOp <$> fdiv realNumerator denominator
                     <*> fdiv imagNumerator denominator
 
+
+------------------------------------------------------------------------
+-- List IR helpers
+------------------------------------------------------------------------
+
+-- | Allocate one node per element, link them, and return the head pointer.
+-- Elements are pre-evaluated; nodes are allocated straight-line (no loop).
+buildLitList :: (MonadModuleBuilder m, MonadIRBuilder m, MonadError String m, MonadFix m)
+             => ArenaState -> TypeProxy t -> Int -> [Op t] -> m (Op ('ListT t))
+buildLitList arena ty stride elems = do
+  nodePtrs <- mapM (\_ -> arenaAlloc arena stride) elems
+  let nextPtrs = drop 1 nodePtrs ++ [nullI8Ptr]
+  forM_ (zip3 nodePtrs nextPtrs elems) $ \(nodePtr, nextPtr, elemOp) -> do
+    nf <- bitcast nodePtr (AST.ptr (AST.ptr AST.i8))
+    store nf 0 nextPtr
+    storeListElem ty nodePtr elemOp
+  pure $ case nodePtrs of
+    (h:_) -> ListOp h
+    []    -> ListOp nullI8Ptr  -- unreachable: caller guards on non-empty elems
+
+-- | Copy every node from every input-list head ptr into the arena, linking
+-- the copies end-to-end.  All input lists are copied (no sharing).
+buildJoin :: (MonadModuleBuilder m, MonadIRBuilder m, MonadError String m, MonadFix m)
+          => ArenaState -> TypeProxy t -> [Operand] -> m (Op ('ListT t))
+buildJoin arena ty inputHeads = do
+  let stride = listNodeStride ty
+  headSlot <- alloca (AST.ptr AST.i8) Nothing 0
+  store headSlot 0 nullI8Ptr
+  prevSlot <- alloca (AST.ptr AST.i8) Nothing 0
+  store prevSlot 0 nullI8Ptr
+  -- For each input list, copy its nodes and append to the result.
+  forM_ inputHeads $ \inputHead -> do
+    currSlot <- alloca (AST.ptr AST.i8) Nothing 0
+    store currSlot 0 inputHead
+    mdo
+      br copyHead
+      copyHead <- block `named` "join_copy_head"
+      curr <- load currSlot 0
+      done <- icmp P.EQ curr nullI8Ptr
+      condBr done copyExit copyBody
+      copyBody <- block `named` "join_copy_body"
+      newNode <- arenaAlloc arena stride
+      -- Copy element from curr to newNode
+      elemOp <- loadListElem ty curr
+      nf <- bitcast newNode (AST.ptr (AST.ptr AST.i8))
+      store nf 0 nullI8Ptr          -- new node's next = null
+      storeListElem ty newNode elemOp
+      -- Append to result
+      appendNode headSlot prevSlot newNode
+      -- Advance
+      nextPtr <- loadListNext curr
+      store currSlot 0 nextPtr
+      br copyHead
+      copyExit <- block `named` "join_copy_exit"
+      pure ()
+  ListOp <$> load headSlot 0
+
+-- | Filter: keep elements where the predicate callback returns 0 (false).
+-- The callback receives the element slot and returns an i1 Operand.
+buildFilter :: (MonadModuleBuilder m, MonadIRBuilder m, MonadError String m, MonadFix m)
+            => ArenaState -> TypeProxy t -> Operand -> PtrOp t
+            -> (PtrOp t -> m Operand)   -- ^ predicate; keep when result = 0
+            -> m (Op ('ListT t))
+buildFilter arena ty inputHead elemSlot predCb = do
+  let stride = listNodeStride ty
+  headSlot <- alloca (AST.ptr AST.i8) Nothing 0
+  store headSlot 0 nullI8Ptr
+  prevSlot <- alloca (AST.ptr AST.i8) Nothing 0
+  store prevSlot 0 nullI8Ptr
+  currSlot <- alloca (AST.ptr AST.i8) Nothing 0
+  store currSlot 0 inputHead
+  mdo
+    br filterHead
+    filterHead <- block `named` "filter_head"
+    curr <- load currSlot 0
+    done <- icmp P.EQ curr nullI8Ptr
+    condBr done filterExit filterBody
+    filterBody <- block `named` "filter_body"
+    elemOp <- loadListElem ty curr
+    storeOperand elemOp elemSlot
+    shouldRemove <- predCb elemSlot
+    condBr shouldRemove filterAdvance filterAdd
+    filterAdd <- block `named` "filter_add"
+    newNode <- arenaAlloc arena stride
+    nf <- bitcast newNode (AST.ptr (AST.ptr AST.i8))
+    store nf 0 nullI8Ptr
+    storeListElem ty newNode elemOp
+    appendNode headSlot prevSlot newNode
+    br filterAdvance
+    filterAdvance <- block `named` "filter_advance"
+    nextPtr <- loadListNext curr
+    store currSlot 0 nextPtr
+    br filterHead
+    filterExit <- block `named` "filter_exit"
+    pure ()
+  ListOp <$> load headSlot 0
+
+-- | Map: apply a callback to every element, building a new list with the results.
+buildMap :: (MonadModuleBuilder m, MonadIRBuilder m, MonadError String m, MonadFix m)
+         => ArenaState -> TypeProxy t1 -> TypeProxy t2 -> Operand -> PtrOp t1
+         -> (PtrOp t1 -> m (Op t2))   -- ^ transform callback
+         -> m (Op ('ListT t2))
+buildMap arena ty1 ty2 inputHead elemSlot transformCb = do
+  let stride2 = listNodeStride ty2
+  headSlot <- alloca (AST.ptr AST.i8) Nothing 0
+  store headSlot 0 nullI8Ptr
+  prevSlot <- alloca (AST.ptr AST.i8) Nothing 0
+  store prevSlot 0 nullI8Ptr
+  currSlot <- alloca (AST.ptr AST.i8) Nothing 0
+  store currSlot 0 inputHead
+  mdo
+    br mapHead
+    mapHead <- block `named` "map_head"
+    curr <- load currSlot 0
+    done <- icmp P.EQ curr nullI8Ptr
+    condBr done mapExit mapBody
+    mapBody <- block `named` "map_body"
+    elemOp <- loadListElem ty1 curr
+    storeOperand elemOp elemSlot
+    outOp <- transformCb elemSlot
+    newNode <- arenaAlloc arena stride2
+    nf <- bitcast newNode (AST.ptr (AST.ptr AST.i8))
+    store nf 0 nullI8Ptr
+    storeListElem ty2 newNode outOp
+    appendNode headSlot prevSlot newNode
+    nextPtr <- loadListNext curr
+    store currSlot 0 nextPtr
+    br mapHead
+    mapExit <- block `named` "map_exit"
+    pure ()
+  ListOp <$> load headSlot 0
+
+-- | Find: return first element where the predicate callback returns 1 (true),
+-- or the default value if no element matches.
+buildFind :: (MonadModuleBuilder m, MonadIRBuilder m, MonadError String m, MonadFix m)
+          => ArenaState -> TypeProxy t -> Operand -> PtrOp t -> Op t
+          -> (PtrOp t -> m Operand)  -- ^ predicate callback
+          -> m (Op t)
+buildFind _arena ty inputHead elemSlot defOp predCb = do
+  resultSlot <- allocaOp ty
+  storeOperand defOp resultSlot
+  currSlot <- alloca (AST.ptr AST.i8) Nothing 0
+  store currSlot 0 inputHead
+  mdo
+    br findHead
+    findHead <- block `named` "find_head"
+    curr <- load currSlot 0
+    done <- icmp P.EQ curr nullI8Ptr
+    condBr done findExit findBody
+    findBody <- block `named` "find_body"
+    elemOp <- loadListElem ty curr
+    storeOperand elemOp elemSlot
+    matched <- predCb elemSlot
+    condBr matched findFound findAdvance
+    findFound <- block `named` "find_found"
+    storeOperand elemOp resultSlot
+    br findExit
+    findAdvance <- block `named` "find_advance"
+    nextPtr <- loadListNext curr
+    store currSlot 0 nextPtr
+    br findHead
+    findExit <- block `named` "find_exit"
+    pure ()
+  derefOperand resultSlot
+
+-- | Count the number of nodes in a linked list.
+buildLength :: (MonadModuleBuilder m, MonadIRBuilder m, MonadError String m, MonadFix m)
+            => Operand     -- ^ head ptr
+            -> AST.Type    -- ^ element LLVM type (unused; for sizing only)
+            -> m (Op 'IntegerT)
+buildLength inputHead _elemTy = do
+  countSlot <- alloca AST.i32 Nothing 0
+  store countSlot 0 (C.int32 0)
+  currSlot <- alloca (AST.ptr AST.i8) Nothing 0
+  store currSlot 0 inputHead
+  mdo
+    br lenHead
+    lenHead <- block `named` "length_head"
+    curr <- load currSlot 0
+    done <- icmp P.EQ curr nullI8Ptr
+    condBr done lenExit lenBody
+    lenBody <- block `named` "length_body"
+    n <- load countSlot 0
+    n' <- add n (C.int32 1)
+    store countSlot 0 n'
+    nextPtr <- loadListNext curr
+    store currSlot 0 nextPtr
+    br lenHead
+    lenExit <- block `named` "length_exit"
+    pure ()
+  IntegerOp <$> load countSlot 0
+
+-- | 1-based list indexing.  For cyclic = False: positive indices count from
+-- the front, negative from the back.  For cyclic = True: wraps around.
+-- Out-of-bounds returns a zero-initialised element (undefined behaviour by spec).
+buildIndex :: (MonadModuleBuilder m, MonadIRBuilder m, MonadError String m, MonadFix m)
+           => ArenaState -> TypeProxy t -> Bool -> Operand -> Operand
+           -> m (Op t)
+buildIndex _arena ty cyclic inputHead iOp = do
+  -- Allocate all slots up front (keeps allocas in the entry region).
+  stepSlot   <- alloca AST.i32 Nothing 0
+  currSlot   <- alloca (AST.ptr AST.i8) Nothing 0
+  resultSlot <- allocaOp ty
+  store currSlot 0 inputHead
+  -- Compute 0-based step count.  We always compute the length because we need
+  -- it for both cyclic wrapping and negative non-cyclic indices.
+  len <- getIntegerOp <$> buildLength inputHead (toLLVMType ty)
+  if cyclic
+    then do
+      -- step = ((i - 1) mod len + len) mod len   (handles any sign)
+      i1   <- sub iOp (C.int32 1)
+      r    <- srem i1 len
+      r'   <- add r len
+      step <- srem r' len
+      store stepSlot 0 step
+    else do
+      -- i >= 1: step = i - 1 (0-based from front)
+      -- i <= 0 (incl. negative): step = len + i  (0-based from back)
+      isNeg   <- icmp P.SLE iOp (C.int32 0)
+      posStep <- sub iOp (C.int32 1)
+      negStep <- add len iOp
+      finalStep <- select isNeg negStep posStep
+      store stepSlot 0 finalStep
+  -- Walk 'step' steps from the head.
+  mdo
+    br stepHead
+    stepHead <- block `named` "index_step"
+    step <- load stepSlot 0
+    curr <- load currSlot 0
+    atTarget <- icmp P.EQ step (C.int32 0)
+    isNull   <- icmp P.EQ curr nullI8Ptr
+    atEnd    <- I.or atTarget isNull
+    condBr atEnd stepDone stepAdvance
+    stepAdvance <- block `named` "index_advance"
+    step' <- sub step (C.int32 1)
+    store stepSlot 0 step'
+    nextPtr <- loadListNext curr
+    store currSlot 0 nextPtr
+    br stepHead
+    stepDone <- block `named` "index_done"
+    pure ()
+  -- Load element or return zero on out-of-bounds.
+  curr     <- load currSlot 0
+  isNull   <- icmp P.EQ curr nullI8Ptr
+  mdo
+    condBr isNull oobBb elemBb
+    oobBb <- block `named` "index_oob"
+    br mergeBb                           -- resultSlot stays zero-initialised
+    elemBb <- block `named` "index_elem"
+    curr2 <- load currSlot 0
+    e <- loadListElem ty curr2
+    storeOperand e resultSlot
+    br mergeBb
+    mergeBb <- block `named` "index_merge"
+    pure ()
+  derefOperand resultSlot
+
+-- | Build an integer range list [lo..hi] in the arena.
+buildRange :: (MonadModuleBuilder m, MonadIRBuilder m, MonadError String m, MonadFix m)
+           => ArenaState -> Operand -> Operand -> m (Op ('ListT 'IntegerT))
+buildRange arena loOp hiOp = do
+  let stride = listNodeStride IntegerType
+  headSlot <- alloca (AST.ptr AST.i8) Nothing 0
+  store headSlot 0 nullI8Ptr
+  prevSlot <- alloca (AST.ptr AST.i8) Nothing 0
+  store prevSlot 0 nullI8Ptr
+  iSlot <- alloca AST.i32 Nothing 0
+  store iSlot 0 loOp
+  mdo
+    br rangeHead
+    rangeHead <- block `named` "range_head"
+    i <- load iSlot 0
+    past <- icmp P.SGT i hiOp
+    condBr past rangeExit rangeBody
+    rangeBody <- block `named` "range_body"
+    newNode <- arenaAlloc arena stride
+    nf <- bitcast newNode (AST.ptr (AST.ptr AST.i8))
+    store nf 0 nullI8Ptr
+    storeListElem IntegerType newNode (IntegerOp i)
+    appendNode headSlot prevSlot newNode
+    i' <- add i (C.int32 1)
+    store iSlot 0 i'
+    br rangeHead
+    rangeExit <- block `named` "range_exit"
+    pure ()
+  ListOp <$> load headSlot 0
+
+-- | Append a new node to the result list tracked by (headSlot, prevSlot).
+-- headSlot holds the head ptr (null = list is empty so far).
+-- prevSlot holds the previous node ptr (null = no previous node yet).
+appendNode :: (MonadModuleBuilder m, MonadIRBuilder m, MonadError String m, MonadFix m)
+           => Operand   -- ^ headSlot (i8**, alloca)
+           -> Operand   -- ^ prevSlot (i8**, alloca)
+           -> Operand   -- ^ newNode  (i8*)
+           -> m ()
+appendNode headSlot prevSlot newNode = do
+  prev <- load prevSlot 0
+  mdo
+    isFirst <- icmp P.EQ prev nullI8Ptr
+    condBr isFirst firstBb linkBb
+    firstBb <- block `named` "append_first"
+    store headSlot 0 newNode
+    br mergeBb
+    linkBb <- block `named` "append_link"
+    prevNextField <- bitcast prev (AST.ptr (AST.ptr AST.i8))
+    store prevNextField 0 newNode
+    br mergeBb
+    mergeBb <- block `named` "append_merge"
+    pure ()
+  store prevSlot 0 newNode
 
 getGetExtern :: (MonadModuleBuilder m, MonadIRBuilder m, MonadError String m)
              => m (String -> Operand)

--- a/fractalstream-backend-llvm/src/Backend/LLVM/Value.hs
+++ b/fractalstream-backend-llvm/src/Backend/LLVM/Value.hs
@@ -18,6 +18,7 @@ import LLVM.IRBuilder.Monad
 import LLVM.IRBuilder.Instruction
 import qualified LLVM.IRBuilder.Constant as C
 import qualified LLVM.AST.IntegerPredicate as P
+import qualified LLVM.AST.IntegerPredicate as IP
 import qualified LLVM.AST.FloatingPointPredicate as P
 import qualified LLVM.IRBuilder.Instruction as I
 import qualified LLVM.AST.Type as AST
@@ -538,19 +539,40 @@ buildValue getExtern arena = indexedFold go'
 ------------------------------------------------------------------------
 
 -- | Allocate one node per element, link them, and return the head pointer.
--- Elements are pre-evaluated; nodes are allocated straight-line (no loop).
+-- Elements are pre-evaluated.  A literal has a known length, so we do a single
+-- up-front bounds check: if the whole list will not fit, set the overflow flag
+-- (pixel goes magenta) and return the empty list.  Otherwise every per-node
+-- 'arenaAlloc' below is guaranteed to succeed, so no null can be written.
 buildLitList :: (MonadModuleBuilder m, MonadIRBuilder m, MonadError String m, MonadFix m)
              => ArenaState -> TypeProxy t -> Int -> [Op t] -> m (Op ('ListT t))
-buildLitList arena ty stride elems = do
-  nodePtrs <- mapM (\_ -> arenaAlloc arena stride) elems
+buildLitList arena ty stride elems = mdo
+  headSlot <- alloca (AST.ptr AST.i8) Nothing 0
+  store headSlot 0 nullI8Ptr
+
+  -- Will all (length elems) nodes fit from the current bump position?
+  bump    <- load (asBumpAlloca arena) 0
+  needEnd  <- gep bump [C.int32 (fromIntegral (stride * length elems))]
+  overflow <- icmp IP.UGT needEnd (asArenaEnd arena)   -- unsigned pointer compare
+  condBr overflow litOverflow litBuild
+
+  litOverflow <- block `named` "lit_overflow"
+  store (asOverflowFlag arena) 0 (C.bit 1)
+  br litDone
+
+  litBuild <- block `named` "lit_build"
+  nodePtrs <- mapM (const (arenaAlloc arena stride)) elems
   let nextPtrs = drop 1 nodePtrs ++ [nullI8Ptr]
   forM_ (zip3 nodePtrs nextPtrs elems) $ \(nodePtr, nextPtr, elemOp) -> do
     nf <- bitcast nodePtr (AST.ptr (AST.ptr AST.i8))
     store nf 0 nextPtr
     storeListElem ty nodePtr elemOp
-  pure $ case nodePtrs of
-    (h:_) -> ListOp h
-    []    -> ListOp nullI8Ptr  -- unreachable: caller guards on non-empty elems
+  case nodePtrs of
+    (h:_) -> store headSlot 0 h
+    []    -> pure ()
+  br litDone
+
+  litDone <- block `named` "lit_done"
+  ListOp <$> load headSlot 0
 
 -- | Copy every node from every input-list head ptr into the arena, linking
 -- the copies end-to-end.  All input lists are copied (no sharing).
@@ -574,6 +596,9 @@ buildJoin arena ty inputHeads = do
       condBr done copyExit copyBody
       copyBody <- block `named` "join_copy_body"
       newNode <- arenaAlloc arena stride
+      isNull <- icmp P.EQ newNode nullI8Ptr   -- arena overflow: bail with partial list
+      condBr isNull copyExit copyAlloc
+      copyAlloc <- block `named` "join_copy_alloc"
       -- Copy element from curr to newNode
       elemOp <- loadListElem ty curr
       nf <- bitcast newNode (AST.ptr (AST.ptr AST.i8))
@@ -616,6 +641,9 @@ buildFilter arena ty inputHead elemSlot predCb = do
     condBr shouldRemove filterAdvance filterAdd
     filterAdd <- block `named` "filter_add"
     newNode <- arenaAlloc arena stride
+    isNull <- icmp P.EQ newNode nullI8Ptr   -- arena overflow: bail with partial list
+    condBr isNull filterExit filterStore
+    filterStore <- block `named` "filter_store"
     nf <- bitcast newNode (AST.ptr (AST.ptr AST.i8))
     store nf 0 nullI8Ptr
     storeListElem ty newNode elemOp
@@ -653,6 +681,9 @@ buildMap arena ty1 ty2 inputHead elemSlot transformCb = do
     storeOperand elemOp elemSlot
     outOp <- transformCb elemSlot
     newNode <- arenaAlloc arena stride2
+    isNull <- icmp P.EQ newNode nullI8Ptr   -- arena overflow: bail with partial list
+    condBr isNull mapExit mapStore
+    mapStore <- block `named` "map_store"
     nf <- bitcast newNode (AST.ptr (AST.ptr AST.i8))
     store nf 0 nullI8Ptr
     storeListElem ty2 newNode outOp
@@ -808,6 +839,9 @@ buildRange arena loOp hiOp = do
     condBr past rangeExit rangeBody
     rangeBody <- block `named` "range_body"
     newNode <- arenaAlloc arena stride
+    isNull <- icmp P.EQ newNode nullI8Ptr   -- arena overflow: bail with partial list
+    condBr isNull rangeExit rangeAlloc
+    rangeAlloc <- block `named` "range_alloc"
     nf <- bitcast newNode (AST.ptr (AST.ptr AST.i8))
     store nf 0 nullI8Ptr
     storeListElem IntegerType newNode (IntegerOp i)

--- a/fractalstream-backend-llvm/src/Backend/LLVM/Value.hs
+++ b/fractalstream-backend-llvm/src/Backend/LLVM/Value.hs
@@ -333,8 +333,7 @@ buildValue getExtern arena = indexedFold go'
       NegI i -> i >>= \case
          (IntegerOp x) -> IntegerOp <$> sub (C.int32 0) x
       PowI mx my -> ((,) <$> mx <*> my) >>= \case
-         (IntegerOp x, IntegerOp n) ->
-           IntegerOp <$> call (getExtern "powi") [(x, []), (n, [])]
+         (IntegerOp x, IntegerOp n) -> IntegerOp <$> intPow x n
       AbsI i -> i >>= \case
         IntegerOp x -> IntegerOp <$> call (getExtern "absi") [(x, []), (C.bit 0, [])]
 
@@ -877,12 +876,39 @@ appendNode headSlot prevSlot newNode = do
     pure ()
   store prevSlot 0 newNode
 
+-- | Emit a loop computing @base ^ expo@ for a non-negative integer exponent by
+-- repeated multiplication.  This matches the interpreter's integer power and
+-- replaces a bogus @llvm.powi.i32@ "intrinsic" (LLVM's @llvm.powi@ only takes a
+-- floating-point base, so the old declaration produced garbage when actually
+-- called — which only happened from tools, since viewer code's constant
+-- exponents are rewritten to multiplications).  A negative exponent yields 1.
+intPow :: (MonadModuleBuilder m, MonadIRBuilder m, MonadFix m)
+       => Operand -> Operand -> m Operand
+intPow base expo = mdo
+  resultSlot <- alloca AST.i32 Nothing 0
+  store resultSlot 0 (C.int32 1)
+  eSlot <- alloca AST.i32 Nothing 0
+  store eSlot 0 expo
+  br powHead
+  powHead <- block `named` "ipow_head"
+  e <- load eSlot 0
+  cont <- icmp P.SGT e (C.int32 0)
+  condBr cont powBody powExit
+  powBody <- block `named` "ipow_body"
+  r <- load resultSlot 0
+  r' <- mul r base
+  store resultSlot 0 r'
+  e' <- sub e (C.int32 1)
+  store eSlot 0 e'
+  br powHead
+  powExit <- block `named` "ipow_exit"
+  load resultSlot 0
+
 getGetExtern :: (MonadModuleBuilder m, MonadIRBuilder m, MonadError String m)
              => m (String -> Operand)
 getGetExtern = do
   es <- mapM (\(name, getter) -> (name,) <$> getter) $
     [ ("absi", extern "llvm.abs.i32" [AST.i32, AST.i1] AST.i32)
-    , ("powi", extern "llvm.powi.i32" [AST.i32, AST.i32] AST.i32)
     , ("trunc", extern "llvm.trunc.f64" [AST.double] AST.double)
     , ("floor", extern "llvm.floor.f64" [AST.double] AST.double)
     , ("ceil", extern "llvm.ceil.f64" [AST.double] AST.double)

--- a/fractalstream-backend-llvm/src/Backend/LLVM/Value.hs
+++ b/fractalstream-backend-llvm/src/Backend/LLVM/Value.hs
@@ -756,11 +756,14 @@ buildLength inputHead _elemTy = do
 
 -- | 1-based list indexing.  For cyclic = False: positive indices count from
 -- the front, negative from the back.  For cyclic = True: wraps around.
--- Out-of-bounds returns a zero-initialised element (undefined behaviour by spec).
+-- Out-of-bounds (and indexing an empty list) sets the overflow flag, which the
+-- renderer surfaces as a magenta pixel.  This mirrors the interpreter, which
+-- terminates on out-of-range indices (see LANGUAGE.md); a JIT pixel kernel
+-- can't abort per pixel, so we signal instead of silently returning a value.
 buildIndex :: (MonadModuleBuilder m, MonadIRBuilder m, MonadError String m, MonadFix m)
            => ArenaState -> TypeProxy t -> Bool -> Operand -> Operand
            -> m (Op t)
-buildIndex _arena ty cyclic inputHead iOp = do
+buildIndex arena ty cyclic inputHead iOp = do
   -- Allocate all slots up front (keeps allocas in the entry region).
   stepSlot   <- alloca AST.i32 Nothing 0
   currSlot   <- alloca (AST.ptr AST.i8) Nothing 0
@@ -809,7 +812,8 @@ buildIndex _arena ty cyclic inputHead iOp = do
   mdo
     condBr isNull oobBb elemBb
     oobBb <- block `named` "index_oob"
-    br mergeBb                           -- resultSlot stays zero-initialised
+    store (asOverflowFlag arena) 0 (C.bit 1)  -- out-of-bounds → signal (magenta)
+    br mergeBb                                 -- resultSlot stays zero-initialised
     elemBb <- block `named` "index_elem"
     curr2 <- load currSlot 0
     e <- loadListElem ty curr2

--- a/fractalstream-backend-pure/src/Backend.hs
+++ b/fractalstream-backend-pure/src/Backend.hs
@@ -1,10 +1,14 @@
 module Backend
   ( withBackend
+  , module Actor.Viewer   -- re-export Backend, ToolRunnerFactory, etc.
   ) where
 
 import Actor.Viewer
 import Backend.Pure
 
-withBackend :: (ViewerCompiler -> IO a) -> IO a
+withBackend :: (Backend -> IO a) -> IO a
 withBackend action =
-  action (ViewerCompiler interpretViewer)
+  action Backend
+    { bViewerCompiler    = ViewerCompiler interpretViewer
+    , bToolRunnerFactory = defaultToolRunnerFactory
+    }

--- a/fractalstream-backend-pure/src/Backend.hs
+++ b/fractalstream-backend-pure/src/Backend.hs
@@ -11,4 +11,5 @@ withBackend action =
   action Backend
     { bViewerCompiler    = ViewerCompiler interpretViewer
     , bToolRunnerFactory = defaultToolRunnerFactory
+    , bToolRunner        = defaultToolRunner
     }

--- a/fractalstream-core/src/Actor/Ensemble.hs
+++ b/fractalstream-core/src/Actor/Ensemble.hs
@@ -189,7 +189,9 @@ makeComplexViewer project backend mkViewer someContext configArgs showConfig rer
     vPixelSize <- throwLeft (getDynamic cvPixelSize) >>= newVariable
     let vSaveView = pure ()
 
-    (vDrawCmds, vDrawCmdsChanged, vDrawTo) <- makeToolRunnerForLayer (bToolRunnerFactory backend)
+    (vDrawCmds, vDrawCmdsChanged, vDrawSink) <- makeToolRunnerForLayer (bToolRunnerFactory backend)
+
+    let vBuildToolHandler = runTool (bToolRunner backend) vDrawSink
 
     getDynamic cvCode >>= \case
 

--- a/fractalstream-core/src/Actor/Ensemble.hs
+++ b/fractalstream-core/src/Actor/Ensemble.hs
@@ -25,7 +25,6 @@ import Actor.Tool (Tool)
 import Actor.Viewer
 import Actor.Viewer.Complex
 import Language.Environment
-import Language.Draw
 import Language.Value hiding (Join)
 import Language.Code.Parser (Splices(..), noSplices)
 
@@ -36,10 +35,8 @@ import qualified Data.Set as Set
 
 import Language.Code (usedVarsInCode, SomeCode(..))
 import Language.Value.Evaluator (evaluate)
-import Language.Code.InterpretIO
 import Development.IncludeFile
 
-import Control.Concurrent
 import Control.Exception (Exception, throwIO)
 
 import Data.Codec
@@ -101,13 +98,13 @@ parseEnsembleFromFile path = do
 data HaskellValueOrError :: Symbol -> FSType -> Exp Type
 type instance Eval (HaskellValueOrError name t) = Either String (HaskellType t)
 
-runEnsembleFromSetup :: ViewerCompiler -> UI -> Ensemble -> IO ()
-runEnsembleFromSetup jit UI{..} Ensemble{..} = do
+runEnsembleFromSetup :: Backend -> UI -> Ensemble -> IO ()
+runEnsembleFromSetup backend UI{..} Ensemble{..} = do
 
   -- Get a handle for the ensemble
   project <- newEnsemble
   let rerunSetup = pure ()
-  let runPostSetup = runEnsemblePostSetup project jit makeLayout makeViewer rerunSetup Ensemble{..}
+  let runPostSetup = runEnsemblePostSetup project backend makeLayout makeViewer rerunSetup Ensemble{..}
 
   -- Run the setup panel
   getDynamic ensembleSetup >>= \case
@@ -116,24 +113,24 @@ runEnsembleFromSetup jit UI{..} Ensemble{..} = do
       title <- either (throwIO . BadEnsemble) pure =<< getDynamic coTitle
       runSetup project title coContents runPostSetup
 
-runEnsemble :: ViewerCompiler -> UI -> Ensemble -> IO ()
-runEnsemble jit UI{..} Ensemble{..} = do
+runEnsemble :: Backend -> UI -> Ensemble -> IO ()
+runEnsemble backend UI{..} Ensemble{..} = do
 
   -- Get a handle for the ensemble
   project <- newEnsemble
   let rerunSetup = pure ()
-  runEnsemblePostSetup project jit makeLayout makeViewer rerunSetup Ensemble{..}
+  runEnsemblePostSetup project backend makeLayout makeViewer rerunSetup Ensemble{..}
 
 
 runEnsemblePostSetup :: forall ensembleHandle
                       . ensembleHandle
-                     -> ViewerCompiler
+                     -> Backend
                      -> (ensembleHandle -> String -> Layout -> IO (IO ()))
                      -> (ensembleHandle -> IO () -> Dynamic (Either String SomeEnvironment) -> SomeContext EventArgument_ -> IO () -> IO () -> Viewer -> IO (IO ()))
                      -> IO ()
                      -> Ensemble
                      -> IO ()
-runEnsemblePostSetup project jit mkLayout mkViewer rerunSetup Ensemble{..} = do
+runEnsemblePostSetup project backend mkLayout mkViewer rerunSetup Ensemble{..} = do
 
   -- Make the configuration panel
   (someContext, configArgs, showConfig) <- getDynamic ensembleConfiguration >>= \case
@@ -153,11 +150,11 @@ runEnsemblePostSetup project jit mkLayout mkViewer rerunSetup Ensemble{..} = do
 
   -- Make the viewers
   viewers <- getDynamic ensembleViewers
-  forM_ viewers $ makeComplexViewer project jit mkViewer' someContext configArgs showConfig rerunSetup
+  forM_ viewers $ makeComplexViewer project backend mkViewer' someContext configArgs showConfig rerunSetup
 
 makeComplexViewer :: forall ensembleHandle
                    . ensembleHandle
-                  -> ViewerCompiler
+                  -> Backend
                   -> (ensembleHandle -> IO () -> SomeContext EventArgument_ -> IO () -> IO () -> Viewer -> IO (IO ()))
                   -> SomeContext DynamicValue'
                   -> SomeContext EventArgument_
@@ -165,7 +162,7 @@ makeComplexViewer :: forall ensembleHandle
                   -> IO ()
                   -> ComplexViewer
                   -> IO ()
-makeComplexViewer project jit mkViewer someContext configArgs showConfig rerunSetup ComplexViewer{..} = do
+makeComplexViewer project backend mkViewer someContext configArgs showConfig rerunSetup ComplexViewer{..} = do
    rebuildScript
   where
    rebuildScript = do
@@ -192,7 +189,7 @@ makeComplexViewer project jit mkViewer someContext configArgs showConfig rerunSe
     vPixelSize <- throwLeft (getDynamic cvPixelSize) >>= newVariable
     let vSaveView = pure ()
 
-    (vDrawCmds, vDrawCmdsChanged, vDrawTo) <- makeDrawCommandGetter
+    (vDrawCmds, vDrawCmdsChanged, vDrawTo) <- makeToolRunnerForLayer (bToolRunnerFactory backend)
 
     getDynamic cvCode >>= \case
 
@@ -252,7 +249,7 @@ makeComplexViewer project jit mkViewer someContext configArgs showConfig rerunSe
           withSelectTool <- if coord `Map.member` envToMap env then (:) <$> makeSelectTool coord else pure id
           let vTools = withSelectTool <$> dyn cvTools
 
-          withCompiledViewer jit mprep code $ \fun -> do
+          withCompiledViewer (bViewerCompiler backend) mprep code $ \fun -> do
             let vCodeWithArgs = CodeWithArgs vGetArgs (Just code) (pure fun)
             -- FIXME, we should grab the "close this window" action and do something with it
             void $ mkViewer project showConfig configArgs rerunSetup rebuildScript Viewer{..}
@@ -302,66 +299,6 @@ layoutToArgs = \case
             in SomeContext' (Right $ SomeContext $ Bind name ty arg EmptyContext)
 
 
-makeDrawCommandGetter :: IO (IO [[DrawCommand]], IO Bool, Int -> DrawHandler ScalarIORefM)
-makeDrawCommandGetter = do
-  layersMVar <- newMVar (Map.empty :: Map Int [DrawCommand])
-  dcChanged <- newMVar False
-
-  let consDrawCmd :: Draw_ value env
-                  -> Maybe [Draw_ value env]
-                  -> Maybe [Draw_ value env]
-      consDrawCmd = \case
-        Clear{} -> const (Just [])
-        c -> Just . \case
-          Nothing -> [c]
-          Just cs -> c:cs
-
-  let drawTo :: Int -> DrawHandler ScalarIORefM
-      drawTo n = DrawHandler $ \cmd -> do
-        let emit :: DrawCommand -> StateT (Context IORefTypeOfBinding e) IO ()
-            emit cmd' = liftIO $ do
-              modifyMVar_ dcChanged (pure . const True)
-              modifyMVar_ layersMVar (pure . Map.alter (consDrawCmd cmd') n)
-        case cmd of
-          DrawPoint _env pv -> do
-            p <- eval pv
-            emit (DrawPoint EmptyEnvProxy p)
-          DrawCircle _env doFill rv pv -> do
-            r    <- eval rv
-            p    <- eval pv
-            emit (DrawCircle EmptyEnvProxy doFill r p)
-          DrawLine _env fromv tov -> do
-            from <- eval fromv
-            to   <- eval tov
-            emit (DrawLine EmptyEnvProxy from to)
-          DrawRect _env doFill fromv tov -> do
-            from <- eval fromv
-            to   <- eval tov
-            emit (DrawRect EmptyEnvProxy doFill from to)
-          SetStroke _env cv -> do
-            c <- eval cv
-            emit (SetStroke EmptyEnvProxy c)
-          SetFill _env cv -> do
-            c <- eval cv
-            emit (SetFill EmptyEnvProxy c)
-          Clear _env -> emit (Clear EmptyEnvProxy)
-          Write _env txtv ptv -> do
-            txt <- eval txtv
-            pt <- eval ptv
-            emit (Write EmptyEnvProxy txt pt)
-
-  let getDrawCommands = do
-        tryTakeMVar dcChanged >>= \case
-          Nothing -> pure ()
-          Just _  -> putMVar dcChanged False
-        tryReadMVar layersMVar >>= \case
-          Nothing -> pure [[]]
-          Just m  -> pure (map reverse (Map.elems m))
-
-      drawCommandsChanged = tryReadMVar dcChanged >>= \case
-        Nothing -> pure True
-        Just tf -> pure tf
-  pure (getDrawCommands, drawCommandsChanged, drawTo)
 
   -- | A standard tool for selecting the clicked point
 makeSelectTool :: String -> IO Tool

--- a/fractalstream-core/src/Actor/Event.hs
+++ b/fractalstream-core/src/Actor/Event.hs
@@ -11,7 +11,6 @@ module Actor.Event
   , EventArgument(..)
 
   , Coordinate(..)
-  , buildHandler
   , buildHandlerWith
   , ToolExec
   , ToolRunner(..)
@@ -139,39 +138,57 @@ snapshotEventArgs :: Context EventArgument_ env -> IO (Maybe (Context HaskellVal
 snapshotEventArgs ctx =
   mapContextM @MaybeHaskellValue @HaskellValue (\_ _ -> id) <$> mapContextM (\_ _ -> argGetValue) ctx
 
--- | How a single tool event handler's 'Code' is executed: given a witness for
--- its environment, the argument context, and the code, run it.  The interpreter
--- ignores the proxy and uses 'run'; the LLVM backend uses it to JIT the handler.
+-- | How a tool event handler's 'Code' is /prepared/ for execution: given a
+-- witness for its environment and the code, produce an invoker that runs the
+-- handler against a (per-event) argument context.  Preparation happens once,
+-- when the dispatcher is built; the invoker runs on every event.  The
+-- interpreter prepares trivially (returns a closure over 'run'); the LLVM
+-- backend JIT-compiles the handler during preparation so each event just
+-- marshals arguments and calls the compiled code (rather than recompiling).
 type ToolExec =
-  forall e. EnvironmentProxy e -> Context EventArgument_ e -> Code e -> IO ()
+  forall e. EnvironmentProxy e
+         -> Code e
+         -> IO (Context EventArgument_ e -> IO ())
 
 makeEventHandler :: forall env
                   . (MissingClickArgs env, MissingDragArgs env, MissingUnitArgs env)
                  => ToolExec
                  -> Context EventArgument_ env
                  -> CombinedEventHandler env
-                 -> Double
-                 -> Event
-                 -> Maybe (IO ())
-makeEventHandler exec ctx CombinedEventHandler{..} = \px -> \case
-  Click (x, y) -> onClick <&> \code ->
-    let c = constArg x # constArg y # constArg px # ctx in exec (contextToEnv c) c code
-  DoubleClick (x, y) -> onDoubleClick <&> \code ->
-    let c = constArg x # constArg y # constArg px # ctx in exec (contextToEnv c) c code
-  Drag (x, y) (x', y') -> onDrag <&> \code ->
-    let c = constArg x # constArg y # constArg x' # constArg y' # constArg px # ctx in exec (contextToEnv c) c code
-  DragDone (x, y) (x', y') -> onDragDone <&> \code ->
-    let c = constArg x # constArg y # constArg x' # constArg y' # constArg px # ctx in exec (contextToEnv c) c code
-  Timer name -> Map.lookup name onTimer <&> \(_, code) ->
-    let c = constArg px # ctx in exec (contextToEnv c) c code
-  ButtonPressed name -> Map.lookup name onButton <&> \code ->
-    let c = constArg px # ctx in exec (contextToEnv c) c code
-  Refresh -> onRefresh <&> \code ->
-    let c = constArg px # ctx in exec (contextToEnv c) c code
-  Activated -> onActivated <&> \code ->
-    let c = constArg px # ctx in exec (contextToEnv c) c code
-  Deactivated -> onDeactivated <&> \code ->
-    let c = constArg px # ctx in exec (contextToEnv c) c code
+                 -> IO (Double -> Event -> Maybe (IO ()))
+makeEventHandler exec ctx CombinedEventHandler{..} = do
+  -- Prepare (e.g. JIT-compile) each present handler once.  The dummy contexts
+  -- only serve to recover each branch's 'EnvironmentProxy'; 'contextToEnv'
+  -- ignores the values.
+  let dummyR     = constArg 0 :: EventArgument 'RealT
+      clickEnvP  = contextToEnv (dummyR # dummyR # dummyR # ctx)
+      dragEnvP   = contextToEnv (dummyR # dummyR # dummyR # dummyR # dummyR # ctx)
+      unitEnvP   = contextToEnv (dummyR # ctx)
+  clickRun       <- traverse (exec clickEnvP) onClick
+  dblClickRun    <- traverse (exec clickEnvP) onDoubleClick
+  dragRun        <- traverse (exec dragEnvP)  onDrag
+  dragDoneRun    <- traverse (exec dragEnvP)  onDragDone
+  timerRun       <- traverse (\(i, code) -> (i,) <$> exec unitEnvP code) onTimer
+  buttonRun      <- traverse (exec unitEnvP)  onButton
+  refreshRun     <- traverse (exec unitEnvP)  onRefresh
+  activatedRun   <- traverse (exec unitEnvP)  onActivated
+  deactivatedRun <- traverse (exec unitEnvP)  onDeactivated
+  pure $ \px -> \case
+    Click (x, y) -> clickRun <&> \invoke ->
+      invoke (constArg x # constArg y # constArg px # ctx)
+    DoubleClick (x, y) -> dblClickRun <&> \invoke ->
+      invoke (constArg x # constArg y # constArg px # ctx)
+    Drag (x, y) (x', y') -> dragRun <&> \invoke ->
+      invoke (constArg x # constArg y # constArg x' # constArg y' # constArg px # ctx)
+    DragDone (x, y) (x', y') -> dragDoneRun <&> \invoke ->
+      invoke (constArg x # constArg y # constArg x' # constArg y' # constArg px # ctx)
+    Timer name -> Map.lookup name timerRun <&> \(_, invoke) ->
+      invoke (constArg px # ctx)
+    ButtonPressed name -> Map.lookup name buttonRun <&> \invoke ->
+      invoke (constArg px # ctx)
+    Refresh -> refreshRun <&> \invoke -> invoke (constArg px # ctx)
+    Activated -> activatedRun <&> \invoke -> invoke (constArg px # ctx)
+    Deactivated -> deactivatedRun <&> \invoke -> invoke (constArg px # ctx)
 
 combineEventHandlers :: forall env
                       . Either String (CombinedEventHandler env)
@@ -257,14 +274,7 @@ buildHandlerWith exec (SomeContext ctx) handlers = do
       let combined = case (onDrag combined0, onDragDone combined0) of
             (Just _, Nothing) -> combined0 { onDragDone = Just NoOp }
             _ -> combined0
-      in pure (pure $ makeEventHandler exec ctx combined)
-
--- | The interpreter handler builder: execute each handler through 'run'.
-buildHandler :: DrawHandler ScalarIORefM
-             -> SomeContext EventArgument_
-             -> [SingleEventHandler]
-             -> IO (Either String (Double -> Event -> Maybe (IO ())))
-buildHandler draw = buildHandlerWith (\_ c code -> run draw c code)
+      in Right <$> makeEventHandler exec ctx combined
 
 -- | How a backend turns a tool's parsed event handlers into the event
 -- dispatcher the UI calls.  Given the per-layer draw handler (from the tool
@@ -284,7 +294,7 @@ newtype ToolRunner = ToolRunner
 -- interpreter and emit them into the given layer's 'DrawSink'.
 defaultToolRunner :: ToolRunner
 defaultToolRunner = ToolRunner $ \sink layer ctx handlers ->
-  buildHandlerWith (\_ c code -> run (drawHandlerForSink (sink layer)) c code) ctx handlers
+  buildHandlerWith (\_ code -> pure (\c -> run (drawHandlerForSink (sink layer)) c code)) ctx handlers
 
 -- | Adapt a 'DrawSink' into an interpreter 'DrawHandler': evaluate each draw
 -- command's value arguments and forward the concrete values to the sink.

--- a/fractalstream-core/src/Actor/Event.hs
+++ b/fractalstream-core/src/Actor/Event.hs
@@ -12,12 +12,17 @@ module Actor.Event
 
   , Coordinate(..)
   , buildHandler
+  , buildHandlerWith
+  , ToolExec
+  , ToolRunner(..)
+  , defaultToolRunner
   , makeEventHandler
 
   , constArg
   , mutableVar
   , mutableArg
   , toUserString
+  , snapshotEventArgs
 
   ) where
 
@@ -127,24 +132,46 @@ run draw ctx script = do
                         Just setter -> when (Scalar ty old /= Scalar ty new) (setter ty new)
                     ) ctx'
 
+-- | Read the current value of every argument in a tool's event context,
+-- yielding a concrete 'HaskellValue' context (or 'Nothing' if any argument is
+-- currently unavailable, e.g. an unparsed configuration field).
+snapshotEventArgs :: Context EventArgument_ env -> IO (Maybe (Context HaskellValue env))
+snapshotEventArgs ctx =
+  mapContextM @MaybeHaskellValue @HaskellValue (\_ _ -> id) <$> mapContextM (\_ _ -> argGetValue) ctx
+
+-- | How a single tool event handler's 'Code' is executed: given a witness for
+-- its environment, the argument context, and the code, run it.  The interpreter
+-- ignores the proxy and uses 'run'; the LLVM backend uses it to JIT the handler.
+type ToolExec =
+  forall e. EnvironmentProxy e -> Context EventArgument_ e -> Code e -> IO ()
+
 makeEventHandler :: forall env
                   . (MissingClickArgs env, MissingDragArgs env, MissingUnitArgs env)
-                 => DrawHandler ScalarIORefM
+                 => ToolExec
                  -> Context EventArgument_ env
                  -> CombinedEventHandler env
                  -> Double
                  -> Event
                  -> Maybe (IO ())
-makeEventHandler draw ctx CombinedEventHandler{..} = \px -> \case
-  Click (x, y) -> onClick <&> run draw (constArg x # constArg y # constArg px # ctx)
-  DoubleClick (x, y) -> onDoubleClick <&> run draw (constArg x # constArg y # constArg px # ctx)
-  Drag (x, y) (x', y') -> onDrag <&> run draw (constArg x # constArg y # constArg x' # constArg y' # constArg px # ctx)
-  DragDone (x, y) (x', y') -> onDragDone <&> run draw (constArg x # constArg y # constArg x' # constArg y' # constArg px # ctx)
-  Timer name -> Map.lookup name onTimer <&> run draw (constArg px # ctx) . snd
-  ButtonPressed name -> Map.lookup name onButton <&> run draw (constArg px # ctx)
-  Refresh -> onRefresh <&> run draw (constArg px # ctx)
-  Activated -> onActivated <&> run draw (constArg px # ctx)
-  Deactivated -> onDeactivated <&> run draw (constArg px # ctx)
+makeEventHandler exec ctx CombinedEventHandler{..} = \px -> \case
+  Click (x, y) -> onClick <&> \code ->
+    let c = constArg x # constArg y # constArg px # ctx in exec (contextToEnv c) c code
+  DoubleClick (x, y) -> onDoubleClick <&> \code ->
+    let c = constArg x # constArg y # constArg px # ctx in exec (contextToEnv c) c code
+  Drag (x, y) (x', y') -> onDrag <&> \code ->
+    let c = constArg x # constArg y # constArg x' # constArg y' # constArg px # ctx in exec (contextToEnv c) c code
+  DragDone (x, y) (x', y') -> onDragDone <&> \code ->
+    let c = constArg x # constArg y # constArg x' # constArg y' # constArg px # ctx in exec (contextToEnv c) c code
+  Timer name -> Map.lookup name onTimer <&> \(_, code) ->
+    let c = constArg px # ctx in exec (contextToEnv c) c code
+  ButtonPressed name -> Map.lookup name onButton <&> \code ->
+    let c = constArg px # ctx in exec (contextToEnv c) c code
+  Refresh -> onRefresh <&> \code ->
+    let c = constArg px # ctx in exec (contextToEnv c) c code
+  Activated -> onActivated <&> \code ->
+    let c = constArg px # ctx in exec (contextToEnv c) c code
+  Deactivated -> onDeactivated <&> \code ->
+    let c = constArg px # ctx in exec (contextToEnv c) c code
 
 combineEventHandlers :: forall env
                       . Either String (CombinedEventHandler env)
@@ -212,11 +239,13 @@ singleToCombined env = \case
     SomeUnitHandler script <- getDynamic (dyn code)
     pure $ bimap snd (\h -> noHandlers { onDeactivated = Just h }) (script env)
 
-buildHandler :: DrawHandler ScalarIORefM
-             -> SomeContext EventArgument_
-             -> [SingleEventHandler]
-             -> IO (Either String (Double -> Event -> Maybe (IO ())))
-buildHandler draw (SomeContext ctx) handlers = do
+-- | Parse a tool's event handlers and build its event dispatcher, with handler
+-- execution supplied by the given 'ToolExec' (interpreter or JIT-compiled).
+buildHandlerWith :: ToolExec
+                 -> SomeContext EventArgument_
+                 -> [SingleEventHandler]
+                 -> IO (Either String (Double -> Event -> Maybe (IO ())))
+buildHandlerWith exec (SomeContext ctx) handlers = do
   let env = contextToEnv ctx
   ecombined <- foldl' combineEventHandlers (Right noHandlers) <$> mapM (singleToCombined env) handlers
   case ecombined of
@@ -228,7 +257,47 @@ buildHandler draw (SomeContext ctx) handlers = do
       let combined = case (onDrag combined0, onDragDone combined0) of
             (Just _, Nothing) -> combined0 { onDragDone = Just NoOp }
             _ -> combined0
-      in pure (pure $ makeEventHandler draw ctx combined)
+      in pure (pure $ makeEventHandler exec ctx combined)
+
+-- | The interpreter handler builder: execute each handler through 'run'.
+buildHandler :: DrawHandler ScalarIORefM
+             -> SomeContext EventArgument_
+             -> [SingleEventHandler]
+             -> IO (Either String (Double -> Event -> Maybe (IO ())))
+buildHandler draw = buildHandlerWith (\_ c code -> run draw c code)
+
+-- | How a backend turns a tool's parsed event handlers into the event
+-- dispatcher the UI calls.  Given the per-layer draw handler (from the tool
+-- draw-command accumulator), the layer number, the tool's variable context, and
+-- the parsed handlers, it produces (or fails to produce) a
+-- @Double -> Event -> Maybe (IO ())@ dispatcher.  The pure/interpreter backend
+-- uses 'defaultToolRunner'; the LLVM backend supplies one that JIT-compiles the
+-- handlers.
+newtype ToolRunner = ToolRunner
+  { runTool :: (Int -> DrawSink)
+            -> Int
+            -> SomeContext EventArgument_
+            -> [SingleEventHandler]
+            -> IO (Either String (Double -> Event -> Maybe (IO ()))) }
+
+-- | The interpreter tool runner: evaluate draw values through the pure
+-- interpreter and emit them into the given layer's 'DrawSink'.
+defaultToolRunner :: ToolRunner
+defaultToolRunner = ToolRunner $ \sink layer ctx handlers ->
+  buildHandlerWith (\_ c code -> run (drawHandlerForSink (sink layer)) c code) ctx handlers
+
+-- | Adapt a 'DrawSink' into an interpreter 'DrawHandler': evaluate each draw
+-- command's value arguments and forward the concrete values to the sink.
+drawHandlerForSink :: DrawSink -> DrawHandler ScalarIORefM
+drawHandlerForSink sink = DrawHandler $ \case
+  DrawPoint _ pv          -> eval pv >>= liftIO . dsPoint sink
+  DrawCircle _ fill rv pv -> do r <- eval rv; p <- eval pv; liftIO (dsCircle sink fill r p)
+  DrawLine _ fv tv        -> do f <- eval fv; t <- eval tv; liftIO (dsLine sink f t)
+  DrawRect _ fill fv tv   -> do f <- eval fv; t <- eval tv; liftIO (dsRect sink fill f t)
+  SetStroke _ cv          -> eval cv >>= liftIO . dsStroke sink
+  SetFill _ cv            -> eval cv >>= liftIO . dsFill sink
+  Clear _                 -> liftIO (dsClear sink)
+  Write _ tv pv           -> do txt <- eval tv; pt <- eval pv; liftIO (dsWrite sink txt pt)
 
 type EventDependencies =
   (Dynamic (Either String Splices),

--- a/fractalstream-core/src/Actor/Viewer.hs
+++ b/fractalstream-core/src/Actor/Viewer.hs
@@ -28,6 +28,8 @@ module Actor.Viewer
   , defaultMinRadius
   -- * Backend
   , ToolRunnerFactory(..)
+  , ToolRunner(..)
+  , defaultToolRunner
   , Backend(..)
   , defaultToolRunnerFactory
   ) where
@@ -38,12 +40,12 @@ import Actor.Viewer.Types
 import Data.DynamicValue
 import Actor.Layout (CodeString(..), Dimensions(..), UIScript)
 import Actor.Tool
+import Actor.Event (ToolRunner(..), defaultToolRunner, EventArgument_, SingleEventHandler, Event)
 import Language.Environment
 import Language.Value.Parser
 import Language.Code
 import Language.Draw
 import Language.Code.Parser
-import Language.Code.InterpretIO (ScalarIORefM, IORefTypeOfBinding, eval)
 import Control.Concurrent.MVar
 import Language.Parser.SourceRange
 import Language.Value.Evaluator
@@ -129,10 +131,16 @@ data Viewer = Viewer
   , vListen    :: IO () -> IO (IO ())
   , vDrawCmds  :: IO [[DrawCommand]]
   , vDrawCmdsChanged :: IO Bool
-  , vDrawTo    :: Int -> DrawHandler ScalarIORefM
   , vCodeWithArgs :: CodeWithArgs
   , vTools     :: Dynamic [Tool]
   , vScript    :: UIScript
+  , vBuildToolHandler
+      :: Int
+      -> SomeContext EventArgument_
+      -> [SingleEventHandler]
+      -> IO (Either String (Double -> Event -> Maybe (IO ())))
+    -- ^ Build a tool's event dispatcher for the given draw layer.  Supplied by
+    --   the backend (interpreter or JIT-compiled); see 'ToolRunner'.
   }
 
 snapshotToFile :: Viewer -> Bool -> FilePath -> IO (Maybe String)
@@ -333,7 +341,7 @@ cloneViewer v = do
     , vCodeWithArgs = vCodeWithArgs v
     , vDrawCmds = vDrawCmds v
     , vDrawCmdsChanged = vDrawCmdsChanged v
-    , vDrawTo = vDrawTo v
+    , vBuildToolHandler = vBuildToolHandler v
     , vScript = vScript v
     }
 
@@ -360,11 +368,11 @@ defaultMinRadius = fromRight (error "INTERNAL ERROR: defaultMinRadius") $ parseP
 -- tools.  Returns three things:
 --   * an action to read all accumulated draw commands (grouped by layer),
 --   * an action to check whether any commands have been added since last read,
---   * a function from layer number to a 'DrawHandler' for that layer.
+--   * a function from layer number to a 'DrawSink' for that layer.
 newtype ToolRunnerFactory = ToolRunnerFactory
   { makeToolRunnerForLayer :: IO ( IO [[DrawCommand]]
                                  , IO Bool
-                                 , Int -> DrawHandler ScalarIORefM
+                                 , Int -> DrawSink
                                  )
   }
 
@@ -372,6 +380,9 @@ newtype ToolRunnerFactory = ToolRunnerFactory
 data Backend = Backend
   { bViewerCompiler    :: ViewerCompiler
   , bToolRunnerFactory :: ToolRunnerFactory
+  , bToolRunner        :: ToolRunner
+    -- ^ How tool event handlers are executed: 'defaultToolRunner' (interpreter)
+    --   or a backend-specific JIT-compiled runner.
   }
 
 -- | The default 'ToolRunnerFactory': tool scripts are executed by the
@@ -382,38 +393,31 @@ defaultToolRunnerFactory = ToolRunnerFactory $ do
   layersMVar <- newMVar (Map.empty :: Map Int [DrawCommand])
   dcChanged  <- newMVar False
 
-  let consDrawCmd :: Draw_ value env
-                  -> Maybe [Draw_ value env]
-                  -> Maybe [Draw_ value env]
+  let consDrawCmd :: DrawCommand
+                  -> Maybe [DrawCommand]
+                  -> Maybe [DrawCommand]
       consDrawCmd = \case
         Clear{} -> const (Just [])
         c       -> Just . \case
           Nothing -> [c]
           Just cs -> c : cs
 
-      drawTo :: Int -> DrawHandler ScalarIORefM
-      drawTo n = DrawHandler $ \cmd -> do
-        let emit :: DrawCommand -> StateT (Context IORefTypeOfBinding e) IO ()
-            emit cmd' = liftIO $ do
-              modifyMVar_ dcChanged  (pure . const True)
-              modifyMVar_ layersMVar (pure . Map.alter (consDrawCmd cmd') n)
-        case cmd of
-          DrawPoint _env pv        -> eval pv >>= \p -> emit (DrawPoint EmptyEnvProxy p)
-          DrawCircle _env fill rv pv -> do
-            r <- eval rv; p <- eval pv
-            emit (DrawCircle EmptyEnvProxy fill r p)
-          DrawLine _env fv tv    -> do
-            fr <- eval fv; to <- eval tv
-            emit (DrawLine EmptyEnvProxy fr to)
-          DrawRect _env fill fv tv -> do
-            fr <- eval fv; to <- eval tv
-            emit (DrawRect EmptyEnvProxy fill fr to)
-          SetStroke _env cv      -> eval cv >>= \c -> emit (SetStroke EmptyEnvProxy c)
-          SetFill   _env cv      -> eval cv >>= \c -> emit (SetFill   EmptyEnvProxy c)
-          Clear _env             -> emit (Clear EmptyEnvProxy)
-          Write _env tv pv       -> do
-            txt <- eval tv; pt <- eval pv
-            emit (Write EmptyEnvProxy txt pt)
+      emit :: Int -> DrawCommand -> IO ()
+      emit n cmd' = do
+        modifyMVar_ dcChanged  (pure . const True)
+        modifyMVar_ layersMVar (pure . Map.alter (consDrawCmd cmd') n)
+
+      mkSink :: Int -> DrawSink
+      mkSink n = DrawSink
+        { dsClear  = emit n (Clear EmptyEnvProxy)
+        , dsStroke = \c -> emit n (SetStroke EmptyEnvProxy c)
+        , dsFill   = \c -> emit n (SetFill EmptyEnvProxy c)
+        , dsPoint  = \p -> emit n (DrawPoint EmptyEnvProxy p)
+        , dsLine   = \f t -> emit n (DrawLine EmptyEnvProxy f t)
+        , dsCircle = \fill r p -> emit n (DrawCircle EmptyEnvProxy fill r p)
+        , dsRect   = \fill f t -> emit n (DrawRect EmptyEnvProxy fill f t)
+        , dsWrite  = \txt pt -> emit n (Write EmptyEnvProxy txt pt)
+        }
 
       getDrawCommands = do
         tryTakeMVar dcChanged >>= \case
@@ -427,4 +431,4 @@ defaultToolRunnerFactory = ToolRunnerFactory $ do
         Nothing -> pure True
         Just tf -> pure tf
 
-  pure (getDrawCommands, drawCommandsChanged, drawTo)
+  pure (getDrawCommands, drawCommandsChanged, mkSink)

--- a/fractalstream-core/src/Actor/Viewer.hs
+++ b/fractalstream-core/src/Actor/Viewer.hs
@@ -26,6 +26,10 @@ module Actor.Viewer
   , defaultIterLimit
   , defaultMaxRadius
   , defaultMinRadius
+  -- * Backend
+  , ToolRunnerFactory(..)
+  , Backend(..)
+  , defaultToolRunnerFactory
   ) where
 
 import FractalStream.Prelude
@@ -39,7 +43,8 @@ import Language.Value.Parser
 import Language.Code
 import Language.Draw
 import Language.Code.Parser
-import Language.Code.InterpretIO (ScalarIORefM)
+import Language.Code.InterpretIO (ScalarIORefM, IORefTypeOfBinding, eval)
+import Control.Concurrent.MVar
 import Language.Parser.SourceRange
 import Language.Value.Evaluator
 import Foreign
@@ -346,3 +351,80 @@ defaultIterLimit, defaultMaxRadius, defaultMinRadius :: ParsedValue
 defaultIterLimit = fromRight (error "INTERNAL ERROR: defaultIterLimit") $ parseParsedValue Map.empty "100"
 defaultMaxRadius = fromRight (error "INTERNAL ERROR: defaultMaxRadius") $ parseParsedValue Map.empty "10"
 defaultMinRadius = fromRight (error "INTERNAL ERROR: defaultMinRadius") $ parseParsedValue Map.empty "0.0001"
+
+------------------------------------------------------------------------
+-- Backend
+------------------------------------------------------------------------
+
+-- | A factory that sets up the draw-command accumulation system for a viewer's
+-- tools.  Returns three things:
+--   * an action to read all accumulated draw commands (grouped by layer),
+--   * an action to check whether any commands have been added since last read,
+--   * a function from layer number to a 'DrawHandler' for that layer.
+newtype ToolRunnerFactory = ToolRunnerFactory
+  { makeToolRunnerForLayer :: IO ( IO [[DrawCommand]]
+                                 , IO Bool
+                                 , Int -> DrawHandler ScalarIORefM
+                                 )
+  }
+
+-- | Bundles a viewer (shader) compiler with the tool execution machinery.
+data Backend = Backend
+  { bViewerCompiler    :: ViewerCompiler
+  , bToolRunnerFactory :: ToolRunnerFactory
+  }
+
+-- | The default 'ToolRunnerFactory': tool scripts are executed by the
+-- pure Haskell interpreter, and draw commands are accumulated in an
+-- in-memory layer map for the UI to paint afterward.
+defaultToolRunnerFactory :: ToolRunnerFactory
+defaultToolRunnerFactory = ToolRunnerFactory $ do
+  layersMVar <- newMVar (Map.empty :: Map Int [DrawCommand])
+  dcChanged  <- newMVar False
+
+  let consDrawCmd :: Draw_ value env
+                  -> Maybe [Draw_ value env]
+                  -> Maybe [Draw_ value env]
+      consDrawCmd = \case
+        Clear{} -> const (Just [])
+        c       -> Just . \case
+          Nothing -> [c]
+          Just cs -> c : cs
+
+      drawTo :: Int -> DrawHandler ScalarIORefM
+      drawTo n = DrawHandler $ \cmd -> do
+        let emit :: DrawCommand -> StateT (Context IORefTypeOfBinding e) IO ()
+            emit cmd' = liftIO $ do
+              modifyMVar_ dcChanged  (pure . const True)
+              modifyMVar_ layersMVar (pure . Map.alter (consDrawCmd cmd') n)
+        case cmd of
+          DrawPoint _env pv        -> eval pv >>= \p -> emit (DrawPoint EmptyEnvProxy p)
+          DrawCircle _env fill rv pv -> do
+            r <- eval rv; p <- eval pv
+            emit (DrawCircle EmptyEnvProxy fill r p)
+          DrawLine _env fv tv    -> do
+            fr <- eval fv; to <- eval tv
+            emit (DrawLine EmptyEnvProxy fr to)
+          DrawRect _env fill fv tv -> do
+            fr <- eval fv; to <- eval tv
+            emit (DrawRect EmptyEnvProxy fill fr to)
+          SetStroke _env cv      -> eval cv >>= \c -> emit (SetStroke EmptyEnvProxy c)
+          SetFill   _env cv      -> eval cv >>= \c -> emit (SetFill   EmptyEnvProxy c)
+          Clear _env             -> emit (Clear EmptyEnvProxy)
+          Write _env tv pv       -> do
+            txt <- eval tv; pt <- eval pv
+            emit (Write EmptyEnvProxy txt pt)
+
+      getDrawCommands = do
+        tryTakeMVar dcChanged >>= \case
+          Nothing -> pure ()
+          Just _  -> putMVar dcChanged False
+        tryReadMVar layersMVar >>= \case
+          Nothing -> pure [[]]
+          Just m  -> pure (map reverse (Map.elems m))
+
+      drawCommandsChanged = tryReadMVar dcChanged >>= \case
+        Nothing -> pure True
+        Just tf -> pure tf
+
+  pure (getDrawCommands, drawCommandsChanged, drawTo)

--- a/fractalstream-core/src/Language/Code/InterpretIO.hs
+++ b/fractalstream-core/src/Language/Code/InterpretIO.hs
@@ -31,14 +31,22 @@ type instance Eval (ScalarIORefM' env) =
 data IORefTypeOfBinding :: Symbol -> FSType -> Exp Type
 type instance Eval (IORefTypeOfBinding name t) = IORef (HaskellType t)
 
--- | Evaluate a value in the current environment
+-- | Evaluate a value in the current environment.
+-- Forces the result eagerly to prevent lazy thunk chains from building up
+-- over loop iterations: each iteration's IORefs would otherwise accumulate
+-- thunks referencing the full context snapshot from that iteration,
+-- retaining O(iterations × context_size) memory.
 eval :: forall t env
       . Value '(env, t)
      -> StateT (Context IORefTypeOfBinding env) IO (HaskellType t)
 eval v = do
   ctxRef <- get
   ctx <- mapContextM (\_ _ -> lift . readIORef) ctxRef
-  pure (evaluate v ctx)
+  let result = evaluate v ctx
+  lift $ case typeOfValue v of
+    ComplexType -> case result of
+      re :+ im -> re `seq` im `seq` return result
+    _ -> result `seq` return result
 
 
 -- | Update a variable in the current environment

--- a/fractalstream-core/src/Language/Draw.hs
+++ b/fractalstream-core/src/Language/Draw.hs
@@ -7,6 +7,7 @@ module Language.Draw
   , transformDrawValuesM
   , DrawHandler(..)
   , runDrawHandler
+  , DrawSink(..)
   ) where
 
 import FractalStream.Prelude
@@ -20,6 +21,25 @@ type DrawCommand = Draw_ ConcreteValue '[]
 
 data ConcreteValue :: Environment -> FSType -> Exp Type
 type instance Eval (ConcreteValue env t) = HaskellType t
+
+-- | A backend-agnostic sink for draw commands, in concrete (plane-coordinate)
+-- Haskell values.  The interpreter adapts a 'DrawHandler' onto one of these;
+-- the LLVM backend wraps each field as a C callback for compiled tools.  There
+-- is no compiled support for 'dsWrite' (text) yet — only the interpreter uses it.
+data DrawSink = DrawSink
+  { dsClear  :: IO ()
+  , dsStroke :: HaskellType 'ColorT -> IO ()
+  , dsFill   :: HaskellType 'ColorT -> IO ()
+  , dsPoint  :: HaskellType ('Pair 'RealT 'RealT) -> IO ()
+  , dsLine   :: HaskellType ('Pair 'RealT 'RealT)
+             -> HaskellType ('Pair 'RealT 'RealT) -> IO ()
+  , dsCircle :: Bool -> HaskellType 'RealT
+             -> HaskellType ('Pair 'RealT 'RealT) -> IO ()
+  , dsRect   :: Bool -> HaskellType ('Pair 'RealT 'RealT)
+             -> HaskellType ('Pair 'RealT 'RealT) -> IO ()
+  , dsWrite  :: HaskellType 'TextT
+             -> HaskellType ('Pair 'RealT 'RealT) -> IO ()
+  }
 
 data DrawHandler (code :: Environment -> Exp Type) where
   DrawHandler :: forall code

--- a/fractalstream-core/src/Language/Value/Typecheck.hs
+++ b/fractalstream-core/src/Language/Value/Typecheck.hs
@@ -555,8 +555,14 @@ tcRange x y sr = \case
   ty -> throwError (Surprise sr "the result of a range operation" "a list of integers" (Expected $ an ty))
 
 tcLength :: ParsedValue -> CheckedValue
-tcLength _lst sr = \case
-  IntegerType -> throwError (internal $ Advice sr "`length` has not been implemented yet")
+tcLength lst sr = \case
+  IntegerType -> tryEachType (Advice sr "The argument to `length` should be a list.")
+    [ Length BooleanType <$> atType lst (ListType BooleanType)
+    , Length IntegerType <$> atType lst (ListType IntegerType)
+    , Length RealType    <$> atType lst (ListType RealType)
+    , Length ComplexType <$> atType lst (ListType ComplexType)
+    , Length ColorType   <$> atType lst (ListType ColorType)
+    ]
   ty -> throwError (Surprise sr "the result of a length operation" "an integer" (Expected $ an ty))
 
 tcIndex :: Bool -> ParsedValue -> ParsedValue -> CheckedValue

--- a/fractalstream-ui-wx/src/Main.hs
+++ b/fractalstream-ui-wx/src/Main.hs
@@ -30,7 +30,7 @@ import Control.Exception (Exception, catch, ErrorCall(..))
 import qualified Data.ByteString as BS
 
 main :: IO ()
-main = withBackend $ \complexViewerCompiler -> start $ do
+main = withBackend $ \backend -> start $ do
 
   wxcAppSetAppName "FractalStream"
 
@@ -65,7 +65,7 @@ main = withBackend $ \complexViewerCompiler -> start $ do
           let sessionSave = save prj projectWindow sessionUnsaved
           let si = SessionInfo{..}
           modifyValue activeSessions (si :)
-          runEnsemble complexViewerCompiler
+          runEnsemble backend
             (viewProject (objectCast projectWindow) (makeMenuBar ProjectActions{..}) sessionSave)
             prj
 
@@ -79,7 +79,7 @@ main = withBackend $ \complexViewerCompiler -> start $ do
         let sessionSave = save prj projectWindow sessionUnsaved
         let si = SessionInfo{..}
         modifyValue activeSessions (si :)
-        runEnsembleFromSetup complexViewerCompiler
+        runEnsembleFromSetup backend
             (viewProject (objectCast projectWindow) (makeMenuBar ProjectActions{..}) sessionSave)
             prj
 

--- a/fractalstream-ui-wx/src/UI/ProjectViewer.hs
+++ b/fractalstream-ui-wx/src/UI/ProjectViewer.hs
@@ -35,7 +35,7 @@ import Actor.Layout
 import Actor.Configuration
 import Actor.Viewer
 import Actor.Ensemble (layoutToArgs)
-import Actor.Event (Event(..), buildHandler, EventArgument_)
+import Actor.Event (Event(..), EventArgument_)
 import Language.Type
 import Language.Draw
 import Language.Environment
@@ -974,7 +974,7 @@ makeWxComplexViewer projectWindow addMenuBar saveSession raiseConfigWindow confi
       layer <- getDynamic toolDrawLayer
       getDynamic toolConfig >>= \case
         Nothing -> do
-          getDynamic (dyn toolEventHandlers) >>= (buildHandler (vDrawTo layer) (SomeContext configValues)) >>= \case
+          getDynamic (dyn toolEventHandlers) >>= (vBuildToolHandler layer (SomeContext configValues)) >>= \case
             Left err -> do
               n <- getDynamic (source $ tiName toolInfo)
               putStrLn ("Problem with tool " ++ n ++ ": " ++ err)
@@ -999,7 +999,7 @@ makeWxComplexViewer projectWindow addMenuBar saveSession raiseConfigWindow confi
           case toolContext0 <> SomeContext' (Right $ SomeContext configValues) of
             SomeContext' (Left _) -> setValue' toolEventHandler (\_ _ -> Nothing)
             SomeContext' (Right toolContext) -> do
-              getDynamic (dyn toolEventHandlers) >>= (buildHandler (vDrawTo layer) toolContext) >>= \case
+              getDynamic (dyn toolEventHandlers) >>= (vBuildToolHandler layer toolContext) >>= \case
                 Left err -> do
                   putStrLn ("Problem with tool " ++ n ++ ": " ++ err)
                   setValue' toolEventHandler (\_ _ -> Nothing)

--- a/test-scripts/list-arena-overflow.yaml
+++ b/test-scripts/list-arena-overflow.yaml
@@ -1,0 +1,39 @@
+viewers:
+  - title: Arena overflow test
+    style: complex-plane
+    size: 512x512
+    resizable: true
+    z-coord: z
+    initial-center: 0
+    initial-pixel-size: 1/128
+
+    code: |
+      # Arena overflow visual test
+      # ─────────────────────────
+      # Arena capacity : 1 MB = 1 048 576 bytes
+      # Integer list-node stride : 16 bytes  (8-byte next-ptr + 4-byte i32, rounded to 8)
+      # Max nodes before overflow: 1 048 576 / 16 = 65 536
+      #
+      # n grows linearly with re(z).  Overflow boundary:
+      #   50 000 * (re z + 1.5) = 65 536  →  re z ≈ -0.19
+      # In a ±2-unit, 512-pixel-wide view that is ~pixel 232 from the left.
+      #
+      # Expected appearance
+      #   Left  of boundary (~232 px): blue-to-green gradient
+      #   Right of boundary (~280 px): solid magenta
+      #
+      # If any of those rightmost pixels are NOT magenta after building with
+      # the overflow-flag patch, the signal is broken.
+
+      n : ℤ ⭠ round(50000.0 * (re z + 1.5))
+
+      # Horizontal gradient so the safe region is clearly distinguishable
+      color ⭠ blend(re z / 2.0 + 0.5, green, dark blue)
+
+      if n > 0:
+        xs : List of ℤ ⭠ range(1, n)
+        len : ℤ ⭠ length(xs)
+
+        # Shade by traversed length: confirms list was actually walked, not just allocated.
+        # blend clamps to [0,1] so large-but-not-overflow values stay in the green band.
+        color ⭠ blend(re z / 2.0 + 0.5, light green, dark green)

--- a/test-scripts/list-color-elements.yaml
+++ b/test-scripts/list-color-elements.yaml
@@ -1,0 +1,27 @@
+# Tests: List of Color, for-each, index
+# A list of colors is indexed by which Mandelbrot orbit period the pixel belongs to.
+# Simpler test: config list of 4 colors; shader picks one based on quadrant.
+viewer:
+  title: List of Color Elements
+  style: complex-plane
+  size: 512x512
+  resizable: true
+  z-coord: z
+  initial-center: 0
+  initial-pixel-size: 1/64
+  code: |
+    # Pick quadrant index (1-based, cycling through 4 colors)
+    qx : Z <- if re z >= 0 then 1 else 0
+    qy : Z <- if im z >= 0 then 1 else 0
+    idx : Z <- qx + 2 * qy + 1
+    color <- palette @@ idx
+
+configuration:
+  title: Configuration
+  size: 400x100
+  vertical-contents:
+    - text-entry:
+        label: "Palette (4 colors)"
+        value: "red, green, blue, yellow"
+        type: List of Color
+        variable: palette

--- a/test-scripts/list-color-elements.yaml
+++ b/test-scripts/list-color-elements.yaml
@@ -1,6 +1,5 @@
-# Tests: List of Color, for-each, index
-# A list of colors is indexed by which Mandelbrot orbit period the pixel belongs to.
-# Simpler test: config list of 4 colors; shader picks one based on quadrant.
+# Tests: List of Color, index
+# Config list of 4 colors; shader picks one based on quadrant.
 viewer:
   title: List of Color Elements
   style: complex-plane

--- a/test-scripts/list-combined.yaml
+++ b/test-scripts/list-combined.yaml
@@ -8,7 +8,7 @@ viewer:
   resizable: true
   z-coord: z
   initial-center: 0
-  initial-pixel-size: 1/128
+  initial-pixel-size: 1/8
   code: |
     combined : List of R <- join(listA, listB)
     positives : List of R <- remove(combined, x -> x <= 0)

--- a/test-scripts/list-combined.yaml
+++ b/test-scripts/list-combined.yaml
@@ -1,5 +1,5 @@
-# Tests: join + remove + transform + find in one shader (List of ℝ)
-# Pipeline: join two lists, remove negatives, square remaining, find first > threshold.
+# Tests: join + remove + transform + find in one script (List of ℝ)
+# Pipeline: join two lists, remove nonpositives, square remaining, find first > threshold.
 # Expected: single bright band at the found value; grey if none found.
 viewer:
   title: List Pipeline (join→remove→transform→find)

--- a/test-scripts/list-combined.yaml
+++ b/test-scripts/list-combined.yaml
@@ -1,0 +1,38 @@
+# Tests: join + remove + transform + find in one shader (List of ℝ)
+# Pipeline: join two lists, remove negatives, square remaining, find first > threshold.
+# Expected: single bright band at the found value; grey if none found.
+viewer:
+  title: List Pipeline (join→remove→transform→find)
+  style: complex-plane
+  size: 512x512
+  resizable: true
+  z-coord: z
+  initial-center: 0
+  initial-pixel-size: 1/128
+  code: |
+    combined : List of R <- join(listA, listB)
+    positives : List of R <- remove(combined, x -> x <= 0)
+    squared : List of R <- transform(positives, x -> x * x)
+    result : R <- find(squared, x -> x > threshold, -1)
+    d : R <- |re z - result|
+    color <- if result < 0 then grey else blend(exp(-d * 15), white, black)
+
+configuration:
+  title: Configuration
+  size: 400x200
+  vertical-contents:
+    - text-entry:
+        label: "List A"
+        value: "-3, -1, 2, 4"
+        type: List of ℝ
+        variable: listA
+    - text-entry:
+        label: "List B"
+        value: "-2, 0.5, 1, 3"
+        type: List of ℝ
+        variable: listB
+    - text-entry:
+        label: "Threshold"
+        value: "5"
+        type: ℝ
+        variable: threshold

--- a/test-scripts/list-find.yaml
+++ b/test-scripts/list-find.yaml
@@ -1,0 +1,31 @@
+# Tests: find (List of ℝ)
+# Finds the first element > threshold in a config list.
+# Pixel is colored white if z is close to that found value, black otherwise.
+# Expected: single bright band at the first element of myList that exceeds threshold.
+viewer:
+  title: List Find
+  style: complex-plane
+  size: 512x512
+  resizable: true
+  z-coord: z
+  initial-center: 0
+  initial-pixel-size: 1/64
+  code: |
+    found : R <- find(myList, x -> x > threshold, -99)
+    d : R <- |re z - found|
+    color <- if found = -99 then grey else blend(exp(-d * 8), white, black)
+
+configuration:
+  title: Configuration
+  size: 400x150
+  vertical-contents:
+    - text-entry:
+        label: "List"
+        value: "-2, -1, 0.5, 1.5, 2.5"
+        type: List of ℝ
+        variable: myList
+    - text-entry:
+        label: "Threshold"
+        value: "0"
+        type: ℝ
+        variable: threshold

--- a/test-scripts/list-from-config.yaml
+++ b/test-scripts/list-from-config.yaml
@@ -1,0 +1,38 @@
+viewer:
+  title: List from Config
+  style: complex-plane
+  size: 512x512
+  resizable: true
+  z-coord: z
+  initial-center: 0
+  initial-pixel-size: 1/64
+  code: |
+    # Color each pixel by its distance to the nearest point in myList.
+    # Points close to a list element are bright; far points are dark.
+    closest : R <- 1000
+    for each c in myList:
+      d : R <- |z - c|
+      if d < closest:
+        closest <- d
+    color <- blend(exp(-closest * 4), white, black)
+
+  tools:
+    - name: Show points
+      shortcut: s
+      actions:
+        - event: refresh
+          code: |
+            erase
+            use red for stroke
+            for each c in myList:
+              draw circle at c with radius 0.05
+
+configuration:
+  title: Configuration
+  size: 400x100
+  vertical-contents:
+    - text-entry:
+        label: "Points"
+        value: "0, 1, -1, i, -i"
+        type: List of ℂ
+        variable: myList

--- a/test-scripts/list-index.yaml
+++ b/test-scripts/list-index.yaml
@@ -1,0 +1,36 @@
+# Tests: @ (1-based index), @@ (cyclic index), length (List of ℂ)
+# Config list has 5 points. The shader selects one by index and lights it up.
+# Also tests negative index: index -1 should pick the last element.
+viewer:
+  title: List Index
+  style: complex-plane
+  size: 512x512
+  resizable: true
+  z-coord: z
+  initial-center: 0
+  initial-pixel-size: 1/48
+  code: |
+    n : Z <- length(myList)
+    # Direct index (1-based): light up point at 'idx'
+    chosen : ℂ <- myList @ idx
+    # Cyclic index: should wrap; light up a second point
+    chosen2 : ℂ <- myList @@ (idx + n)
+    d1 : R <- |z - chosen|
+    d2 : R <- |z - chosen2|
+    closest : R <- if d1 < d2 then d1 else d2
+    color <- blend(exp(-closest * 8), white, black)
+
+configuration:
+  title: Configuration
+  size: 400x150
+  vertical-contents:
+    - text-entry:
+        label: "Points"
+        value: "0, 1, -1, i, -i"
+        type: List of ℂ
+        variable: myList
+    - text-entry:
+        label: "Index (1-based)"
+        value: "1"
+        type: ℤ
+        variable: idx

--- a/test-scripts/list-join.yaml
+++ b/test-scripts/list-join.yaml
@@ -1,0 +1,34 @@
+# Tests: join, for-each (List of ℂ)
+# Two config lists are joined; shader colors by minimum distance to any point.
+# Expected: bright spots at all 6 points (3 from each list).
+viewer:
+  title: List Join
+  style: complex-plane
+  size: 512x512
+  resizable: true
+  z-coord: z
+  initial-center: 0
+  initial-pixel-size: 1/48
+  code: |
+    all : List of ℂ <- join(listA, listB)
+    closest : R <- 1000
+    for each c in all:
+      d : R <- |z - c|
+      if d < closest:
+        closest <- d
+    color <- blend(exp(-closest * 5), white, black)
+
+configuration:
+  title: Configuration
+  size: 400x150
+  vertical-contents:
+    - text-entry:
+        label: "List A"
+        value: "0, 1, -1"
+        type: List of ℂ
+        variable: listA
+    - text-entry:
+        label: "List B"
+        value: "i, -i, 0.5 + 0.5i"
+        type: List of ℂ
+        variable: listB

--- a/test-scripts/list-literal-complex.yaml
+++ b/test-scripts/list-literal-complex.yaml
@@ -1,0 +1,19 @@
+# Tests: List literal (List of ℂ), for-each, length
+# Expected: 5 bright spots at 0, 1, -1, i, -i; rest dark.
+# The shader builds a literal list each pixel and iterates over it.
+viewer:
+  title: List Literal — Complex
+  style: complex-plane
+  size: 512x512
+  resizable: true
+  z-coord: z
+  initial-center: 0
+  initial-pixel-size: 1/64
+  code: |
+    pts : List of ℂ <- [0, 1, -1, i, -i]
+    closest : R <- 1000
+    for each c in pts:
+      d : R <- |z - c|
+      if d < closest:
+        closest <- d
+    color <- blend(exp(-closest * 6), white, black)

--- a/test-scripts/list-literal-integer.yaml
+++ b/test-scripts/list-literal-integer.yaml
@@ -1,0 +1,22 @@
+# Tests: List literal (List of ℤ), for-each, length
+# Expected: bright horizontal bands at imaginary parts 0, 1, 2, 3 (from the
+# length = 4, used as scaling factor); rest dark.
+viewer:
+  title: List Literal — Integer
+  style: complex-plane
+  size: 512x512
+  resizable: true
+  z-coord: z
+  initial-center: 1.5 + 1.5 i
+  initial-pixel-size: 1/64
+  code: |
+    ns : List of Z <- [0, 1, 2, 3]
+    n : Z <- length(ns)
+    closest : R <- 1000
+    for each k in ns:
+      d : R <- |im z - k|
+      if d < closest:
+        closest <- d
+    # Color also encodes length (n=4 -> white background, else grey)
+    base : R <- if n = 4 then 0.1 else 0.5
+    color <- blend(exp(-closest * 6) * (1 - base) + base, white, black)

--- a/test-scripts/list-literal-real.yaml
+++ b/test-scripts/list-literal-real.yaml
@@ -1,0 +1,18 @@
+# Tests: List literal (List of ℝ), for-each
+# Expected: vertical bright bands at x = -2, -1, 0, 1, 2 (re z only).
+viewer:
+  title: List Literal — Real
+  style: complex-plane
+  size: 512x512
+  resizable: true
+  z-coord: z
+  initial-center: 0
+  initial-pixel-size: 1/64
+  code: |
+    xs : List of R <- [-2, -1, 0, 1, 2]
+    closest : R <- 1000
+    for each x in xs:
+      d : R <- |re z - x|
+      if d < closest:
+        closest <- d
+    color <- blend(exp(-closest * 6), white, black)

--- a/test-scripts/list-lookup.yaml
+++ b/test-scripts/list-lookup.yaml
@@ -1,0 +1,31 @@
+# Tests: with-first-matching (Lookup) in shader (List of ℂ)
+# Finds the first point within radius of z; colors that region red.
+# Points beyond radius get black.
+viewer:
+  title: List Lookup (with first matching)
+  style: complex-plane
+  size: 512x512
+  resizable: true
+  z-coord: z
+  initial-center: 0
+  initial-pixel-size: 1/48
+  code: |
+    color <- black
+
+    with first c matching |z - c| < radius in myList:
+      color <- blend(|z - c| / radius, red, yellow)
+
+configuration:
+  title: Configuration
+  size: 400x150
+  vertical-contents:
+    - text-entry:
+        label: "Points"
+        value: "0, 1, -1, i, -i"
+        type: List of ℂ
+        variable: myList
+    - text-entry:
+        label: "Radius"
+        value: "0.4"
+        type: ℝ
+        variable: radius

--- a/test-scripts/list-range.yaml
+++ b/test-scripts/list-range.yaml
@@ -10,7 +10,7 @@ viewer:
   initial-center: 0
   initial-pixel-size: 1/64
   code: |
-    ns : List of Z <- [lo .. hi]
+    ns : List of Z <- range(lo, hi)
     n : Z <- length(ns)
     closest : R <- 1000
     for each k in ns:

--- a/test-scripts/list-range.yaml
+++ b/test-scripts/list-range.yaml
@@ -1,0 +1,37 @@
+# Tests: range [lo..hi] (List of ℤ), for-each, length
+# Builds a range in the shader and iterates over it.
+# Expected: vertical bright bands at integer x positions from lo to hi.
+viewer:
+  title: List Range
+  style: complex-plane
+  size: 512x512
+  resizable: true
+  z-coord: z
+  initial-center: 0
+  initial-pixel-size: 1/64
+  code: |
+    ns : List of Z <- [lo .. hi]
+    n : Z <- length(ns)
+    closest : R <- 1000
+    for each k in ns:
+      d : R <- |re z - k|
+      if d < closest:
+        closest <- d
+    # Encode length in brightness of far-field to verify count is correct
+    bg : R <- n / 20
+    color <- blend(exp(-closest * 6) + bg, white, black)
+
+configuration:
+  title: Configuration
+  size: 400x150
+  vertical-contents:
+    - text-entry:
+        label: "lo"
+        value: "-3"
+        type: ℤ
+        variable: lo
+    - text-entry:
+        label: "hi"
+        value: "3"
+        type: ℤ
+        variable: hi

--- a/test-scripts/list-remove.yaml
+++ b/test-scripts/list-remove.yaml
@@ -1,0 +1,20 @@
+# Tests: remove, for-each (List of ℝ)
+# Starts with [-3,-2,-1,0,1,2,3]; removes non-negative values; keeps negatives.
+# Expected: bright bands only at x = -3, -2, -1 (left half of view).
+viewer:
+  title: List Remove
+  style: complex-plane
+  size: 512x512
+  resizable: true
+  z-coord: z
+  initial-center: 0
+  initial-pixel-size: 1/64
+  code: |
+    all : List of R <- [-3, -2, -1, 0, 1, 2, 3]
+    negatives : List of R <- remove(all, x -> x >= 0)
+    closest : R <- 1000
+    for each x in negatives:
+      d : R <- |re z - x|
+      if d < closest:
+        closest <- d
+    color <- blend(exp(-closest * 5), white, black)

--- a/test-scripts/list-transform-config.yaml
+++ b/test-scripts/list-transform-config.yaml
@@ -1,0 +1,37 @@
+# Tests: transform, for-each (List of ℂ)
+# Starts with [1, i, -1, -i]; transform squares each element -> [1, -1, 1, -1].
+# After squaring, duplicates collapse so only 2 distinct bright spots at 1 and -1.
+viewer:
+  title: List Transform
+  style: complex-plane
+  size: 512x512
+  resizable: true
+  z-coord: z
+  initial-center: 0
+  initial-pixel-size: 1/48
+  code: |
+    squared : List of ℂ <- transform(pts, w -> w^2)
+    closest : R <- 1000
+    for each c in squared:
+      d : R <- |z - c|
+      if d < closest:
+        closest <- d
+
+    color <- blend(exp(-closest * 8), white, black)
+
+    for each c in pts:
+      d : R <- |z - c|
+      if d < closest:
+        closest <- d
+        color <- blend(exp(-closest * 8), red, black)
+
+
+configuration:
+  title: Configuration
+  size: 400x150
+  vertical-contents:
+    - text-entry:
+        label: "Points"
+        value: "1, i, -1, -i"
+        type: List of ℂ
+        variable: pts

--- a/test-scripts/list-transform.yaml
+++ b/test-scripts/list-transform.yaml
@@ -1,0 +1,20 @@
+# Tests: transform, for-each (List of ℂ)
+# Starts with [1, i, -1, -i]; transform squares each element -> [1, -1, 1, -1].
+# After squaring, duplicates collapse so only 2 distinct bright spots at 1 and -1.
+viewer:
+  title: List Transform
+  style: complex-plane
+  size: 512x512
+  resizable: true
+  z-coord: z
+  initial-center: 0
+  initial-pixel-size: 1/48
+  code: |
+    pts : List of ℂ <- [1, i, -1, -i]
+    squared : List of ℂ <- transform(pts, w -> w^2)
+    closest : R <- 1000
+    for each c in squared:
+      d : R <- |z - c|
+      if d < closest:
+        closest <- d
+    color <- blend(exp(-closest * 8), white, black)


### PR DESCRIPTION
This PR does two things:
- Add lists to the LLVM backend.
- Add a tool compiler.

The first is done by creating an arena allocator pool (one arena per capability, fixed memory size, and owned by the JIT session). Lists are singly linked, and whenever the execution of the script overflows the arena memory chunk or it access an index out-of-bounds, the corresponding pixel gets a magenta color (for visual inspection). 

There are scripts illustrating/testing the overflow behavior and all the list functionalities.

Everything seems to work so far, but I'm still double checking the code. Any suggestions/requests?

There is one divergence from the previous interpreted behavior: the external_rays script has some numerical instability at the base of the rays (possibly because of integer overflow).